### PR TITLE
Add Corrupted Dryad enemy with armor drain ability

### DIFF
--- a/test_sim.py
+++ b/test_sim.py
@@ -34,5 +34,24 @@ class TestMechanics(unittest.TestCase):
         self.assertLessEqual(hero.hp, hero.max_hp)
         self.assertGreaterEqual(hero.hp, 0)
 
+class TestCorruptedDryadAbilities(unittest.TestCase):
+    def test_cursed_thorns(self):
+        hero = sim.Hero("Hero", 10, [])
+        hero.hp = 10
+        hero.armor_pool = 3
+        sim.cursed_thorns(hero)
+        self.assertEqual(hero.hp, 7)
+        self.assertEqual(hero.armor_pool, 0)
+
+    def test_disturbed_flow(self):
+        ctx = {}
+        sim.disturbed_flow(ctx)
+        hero = sim.Hero("Hero", 10, [])
+        hero.fate = 4
+        sim.RNG.seed(1)
+        result = sim.roll_die(5, hero=hero, allow_reroll=not ctx.get("no_reroll", False))
+        self.assertEqual(result, 3)
+        self.assertEqual(hero.fate, 4)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- implement `cursed_thorns` and `disturbed_flow` monster abilities
- disable rerolls when `disturbed-flow` enemies appear
- convert leftover armor to damage for `cursed-thorns`
- rename Dryad enemies to Corrupted Dryads
- expand unit tests for new abilities

## Testing
- `python3 -m py_compile sim.py test_sim.py`
- `python3 -m unittest -v`