### PR TITLE
Add fate spending limits and kill rerolls

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ trials (20 by default).  You can adjust the number of trials by editing the
 Heroes accumulate **Fate** as they progress.  When rolling a die they may
 spend Fate to reroll a result that fails to meet the target defense.  Hercules
 may reroll while above 3 Fate whereas Brynhild requires more than 5.  Fate is
-capped at 10.
+capped at 10.  ``roll_hits`` also checks if a single reroll could finish off an
+enemy and automatically uses Fate when possible.
 
 ## Elemental vulnerability
 

--- a/test_sim.py
+++ b/test_sim.py
@@ -10,6 +10,17 @@ class TestDiceRolls(unittest.TestCase):
         self.assertEqual(result, 2)
         self.assertEqual(hero.fate, 3)
 
+    def test_roll_hits_reroll_for_kill(self):
+        """roll_hits should spend fate when a reroll can kill."""
+        sim.RNG.seed(3)
+        hero = sim.Hero("Hero", 10, [])
+        hero.fate = 5
+        enemy = sim.Enemy("Dummy", 1, 5, sim.Element.NONE, [0, 0, 0, 0])
+        dmg = sim.roll_hits(1, enemy.defense, hero=hero,
+                             enemy=enemy, allow_reroll=True)
+        self.assertEqual(dmg, 1)
+        self.assertEqual(hero.fate, 3)
+
     def test_roll_die_without_reroll(self):
         sim.RNG.seed(1)
         hero = sim.Hero("Hero", 10, [])


### PR DESCRIPTION
## Summary
- enforce hero fate spending rules
- reroll dice in roll_hits if a reroll could finish off the enemy
- note auto-reroll behavior in README
- test rerolling to secure a kill

## Testing
- `python -m unittest -q`