### PR TITLE
Improve upgrade draw logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,6 @@ present.
 After clearing a wave the hero gains one upgrade which is drawn from that
 hero's upgrade pool and permanently added to the deck.  Upgrades allow the deck
 to grow stronger over the course of a run.
+Each pool contains common, uncommon and rare cards weighted 3‑2‑1.  When an
+upgrade is gained, a card is randomly selected from the remaining pool and
+added to the deck.

--- a/sim.py
+++ b/sim.py
@@ -119,10 +119,13 @@ class Hero:
         self.fate = min(FATE_MAX, self.fate + n)
 
     def gain_upgrades(self, n: int = 1) -> None:
-        if not self.upg_pool:
-            return
-        choices = RNG.sample(self.upg_pool, min(n, len(self.upg_pool)))
-        self.deck.cards.extend(choices)
+        """Draw ``n`` upgrades from the weighted pool into the deck."""
+        for _ in range(n):
+            if not self.upg_pool:
+                break
+            card = RNG.choice(self.upg_pool)
+            self.upg_pool.remove(card)
+            self.deck.cards.append(card)
 
     def spend_fate(self, n: int = 1) -> bool:
         """Spend ``n`` fate if above the hero specific threshold."""


### PR DESCRIPTION
## Summary
- remove upgrades from the pool when taken
- document weighted upgrade pools in README

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*