### PR TITLE
Update README and add basic tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Board Game Simulator
 
 This repository contains a small Python script `sim.py` that performs a
-lightweight simulation of a card‑driven board game.  The implementation
+lightweight simulation of a card-driven board game. The implementation
 models a handful of heroes, cards and monsters and demonstrates key mechanics
 such as armor, Fate points, persistent effects and elemental vulnerabilities.
 
@@ -14,30 +14,43 @@ python3 sim.py
 ```
 
 By default the script picks a random hero and resolves a fight against the
-predefined monster waves.  The output prints the win rate across a number of
-trials (20 by default).  You can adjust the number of trials by editing the
+predefined monster waves. The output prints the win rate across a number of
+trials (20 by default). You can adjust the number of trials by editing the
 `N` constant at the bottom of `sim.py`.
 
 ## Fate and rerolls
 
-Heroes accumulate **Fate** as they progress.  When rolling a die they may
-spend Fate to reroll a result that fails to meet the target defense.  Hercules
-may reroll while above 3 Fate whereas Brynhild requires more than 5.  Fate is
-capped at 10.  ``roll_hits`` also checks if a single reroll could finish off an
+Heroes accumulate **Fate** as they progress. When rolling a die they may
+spend Fate to reroll a result that fails to meet the target defense. Hercules
+may reroll while above 3 Fate whereas Brynhild requires more than 5. Fate is
+capped at 10. `roll_hits` also checks if a single reroll could finish off an
 enemy and automatically uses Fate when possible.
 
 ## Elemental vulnerability
 
-Every enemy has an elemental weakness.  When an attack's element matches the
-enemy's vulnerability the damage of each hit is doubled.  This is handled by
+Every enemy has an elemental weakness. When an attack's element matches the
+enemy's vulnerability the damage of each hit is doubled. This is handled by
 `roll_hits` which multiplies the number of hits when a vulnerability is
 present.
 
 ## Upgrades
 
 After clearing a wave the hero gains one upgrade which is drawn from that
-hero's upgrade pool and permanently added to the deck.  Upgrades allow the deck
-to grow stronger over the course of a run.
-Each pool contains common, uncommon and rare cards weighted 3‑2‑1.  When an
-upgrade is gained, a card is randomly selected from the remaining pool and
-added to the deck.
+hero's upgrade pool and permanently added to the deck. Upgrades allow the deck
+to grow stronger over the course of a run. Each pool contains common,
+uncommon and rare cards weighted 3‑2‑1. When an upgrade is gained, a card is
+randomly selected from the remaining pool and added to the deck.
+
+## Waves
+
+A run is a series of **waves** of enemies. Each entry in `ENEMY_WAVES`
+defines the name of the monster and how many appear at once. The hero must
+defeat every wave in sequence without dying. Between waves the hero draws
+additional cards, gains Fate and receives an upgrade.
+
+## Card effects
+
+Attack and utility cards may have effects in addition to their dice or armor
+values. Effects can grant armor, draw cards, or impose temporary conditions on
+monsters. Some effects persist for an exchange or an entire combat, while
+others resolve immediately.

--- a/test_basic.py
+++ b/test_basic.py
@@ -1,0 +1,34 @@
+import unittest
+import sim
+
+class TestBasicMechanics(unittest.TestCase):
+    def test_roll_die_range(self):
+        sim.RNG.seed(0)
+        hero = sim.Hero("Hero", 10, [])
+        hero.fate = 0
+        r = sim.roll_die(5, hero=hero)
+        self.assertTrue(1 <= r <= 8)
+
+    def test_fate_reroll_spent(self):
+        sim.RNG.seed(1)
+        hero = sim.Hero("Hero", 10, [])
+        hero.fate = 4
+        result = sim.roll_die(6, hero=hero)
+        self.assertEqual(result, 2)
+        self.assertEqual(hero.fate, 3)
+
+    def test_vulnerability_doubles_damage(self):
+        sim.RNG.seed(2)
+        dmg = sim.roll_hits(1, 1, element=sim.Element.BRUTAL,
+                             vulnerability=sim.Element.BRUTAL,
+                             allow_reroll=False)
+        self.assertEqual(dmg, 2)
+
+    def test_simple_combat(self):
+        sim.RNG.seed(0)
+        hero = sim.Hero("Hercules", 25, sim.herc_base, sim.herc_pool)
+        result = sim.fight_one(hero)
+        self.assertIn(result, [True, False])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- document waves and card effects in README
- explain running the simulator, Fate, and vulnerabilities
- add a minimal unittest suite for dice rolls, Fate rerolls, vulnerability bonus damage and a simple combat run

## Testing
- `python3 -m unittest -v`