### PR TITLE
Add Musashi hero with new card effects

### DIFF
--- a/test_sim.py
+++ b/test_sim.py
@@ -410,5 +410,27 @@ class TestHymnMechanics(unittest.TestCase):
         sim.resolve_attack(hero, ender, ctx)
         self.assertFalse(hero.active_hymns)
 
+
+class TestMusashiCards(unittest.TestCase):
+    def test_vulnerability_bonus(self):
+        sim.RNG.seed(5)
+        hero = sim.Hero("Musashi", 20, [])
+        card = sim.heaven_earth
+        enemy = sim.Enemy("Dummy", 2, 5, sim.Element.PRECISE, [0, 0, 0, 0])
+        ctx = {"enemies": [enemy]}
+        sim.resolve_attack(hero, card, ctx)
+        self.assertFalse(ctx["enemies"])  # enemy defeated by bonus
+
+    def test_util_before_ranged(self):
+        sim.RNG.seed(7)
+        hero = sim.Hero("Musashi", 20, [])
+        util = sim.dual_moon_guard
+        attack = sim.atk("Arrow", sim.CardType.RANGED, 1)
+        enemy = sim.Enemy("Dummy", 2, 5, sim.Element.NONE, [0, 0, 0, 0])
+        ctx = {"enemies": [enemy]}
+        sim.resolve_attack(hero, util, ctx)
+        sim.resolve_attack(hero, attack, ctx)
+        self.assertFalse(ctx["enemies"])  # bonus damage from armor hook applied
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add helper effects for Musashi (double attacks, vulnerability checks and armor bonuses)
- implement Musashi hero deck and upgrade pools
- include new tests for Musashi card mechanics

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*