### PR TITLE
Fix hero upgrade pool reset

### DIFF
--- a/sim.py
+++ b/sim.py
@@ -94,6 +94,7 @@ class Hero:
     max_hp: int
     base_cards: List[Card]
     upg_pool: List[Card] = field(default_factory=list)
+    _orig_pool: List[Card] = field(init=False, repr=False)
 
     # dynamic state
     fate: int = 0
@@ -104,9 +105,14 @@ class Hero:
     active_hymns: List[Card] = field(default_factory=list)
 
     def __post_init__(self) -> None:
+        # store a copy of the original upgrade pool so ``reset`` can
+        # restore it for subsequent runs
+        self._orig_pool = self.upg_pool[:]
         self.reset()
 
     def reset(self) -> None:
+        # restore upgrade pool to the original state
+        self.upg_pool = self._orig_pool[:]
         self.hp = self.max_hp
         self.fate = 0
         self.armor_pool = 0

--- a/test_basic.py
+++ b/test_basic.py
@@ -30,5 +30,27 @@ class TestBasicMechanics(unittest.TestCase):
         result = sim.fight_one(hero)
         self.assertIn(result, [True, False])
 
+    def test_upgrade_pool_restored_between_fights(self):
+        """Running two fights in a row should start with a full upgrade pool."""
+        sim.RNG.seed(0)
+        hero = sim.Hero("Hercules", 25, sim.herc_base, sim.herc_pool)
+        initial_len = len(hero.upg_pool)
+
+        lengths = []
+        orig_reset = hero.reset
+
+        def wrapped():
+            orig_reset()
+            lengths.append(len(hero.upg_pool))
+
+        hero.reset = wrapped
+
+        sim.fight_one(hero)
+        sim.fight_one(hero)
+
+        hero.reset = orig_reset
+
+        self.assertEqual(lengths, [initial_len, initial_len])
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- reset Hero.upg_pool to the original pool each run
- add regression test to ensure the upgrade pool resets between fights

## Testing
- `python -m unittest`