### PR TITLE
Implement Brynhild hymn logic and new cards

### DIFF
--- a/sim.py
+++ b/sim.py
@@ -557,13 +557,40 @@ herc_rare_upg = [
 herc_pool = weighted_pool(herc_common_upg, herc_uncommon_upg, herc_rare_upg)
 hercules = Hero("Hercules", 25, herc_base, herc_pool)
 
+# Brynhild cards --------------------------------------------------------------
+valkyrie_descent = atk(
+    "Valkyrie's Descent", CardType.MELEE, 1, Element.SPIRITUAL,
+    dmg_per_hymn=1,
+)
+
+hymn_shields = atk("Hymn of Shields", CardType.UTIL, 0, hymn=True)
+
+def _hymn_shields_end(hero: Hero, ctx: Dict[str, object], _enemy: Optional[Enemy]) -> None:
+    if hero.armor_pool < 3:
+        hero.armor_pool += 1
+
+def _hymn_shields_fx(hero: Hero, ctx: Dict[str, object]) -> None:
+    ctx.setdefault("end_hooks", []).append((_hymn_shields_end, None))
+    def per_exchange(h: Hero, c: Dict[str, object]) -> None:
+        c.setdefault("end_hooks", []).append((_hymn_shields_end, None))
+    if (per_exchange, hymn_shields) not in hero.combat_effects:
+        hero.combat_effects.append((per_exchange, hymn_shields))
+
+hymn_shields.effect = _hymn_shields_fx
+
+hymn_storms = atk("Hymn of Storms", CardType.UTIL, 0, effect=end_hymns_fx)
+
+gleaming_spear = atk("Gleaming Spear", CardType.RANGED, 2, Element.DIVINE)
+rally = atk("Rally", CardType.UTIL, 0, effect=draw_cards(1))
+aria = atk("Aria", CardType.UTIL, 0, hymn=True, persistent="combat", effect=hymn_damage(1))
+
 bryn_base = [
-    atk("Descent", CardType.MELEE, 1, Element.SPIRITUAL),
-    atk("Shields", CardType.UTIL, 0, hymn=True, persistent="combat", effect=hymn_armor(1)),
-    atk("Storms", CardType.UTIL, 0, effect=end_hymns_fx),
-    atk("Gleaming Spear", CardType.RANGED, 2, Element.DIVINE),
-    atk("Rally", CardType.UTIL, 0, effect=draw_cards(1)),
-    atk("Aria", CardType.UTIL, 0, hymn=True, persistent="combat", effect=hymn_damage(1)),
+    valkyrie_descent, valkyrie_descent,
+    hymn_shields, hymn_shields,
+    hymn_storms, hymn_storms,
+    gleaming_spear, gleaming_spear,
+    rally, rally,
+    aria, aria,
 ]
 _b_c = [
     atk("Song", CardType.MELEE, 1, Element.SPIRITUAL, effect=gain_fate_fx(1)),
@@ -576,10 +603,12 @@ _b_u = [
     atk("Valkyrie Lance", CardType.RANGED, 3, Element.DIVINE),
     atk("Ballad", CardType.UTIL, 0, hymn=True, persistent="exchange", effect=hymn_damage(1)),
 ]
+thrust_of_destiny = atk("Thrust of Destiny", CardType.MELEE, 2, Element.DIVINE, dmg_per_hymn=1)
 _b_r = [
     atk("Valhalla", CardType.MELEE, 3, Element.DIVINE, effect=temp_vuln(Element.DIVINE)),
     atk("Heaven's Blessing", CardType.UTIL, 0, effect=gain_fate_fx(2), persistent="combat"),
     atk("Requiem", CardType.UTIL, 0, hymn=True, persistent="combat", effect=hymn_damage(2)),
+    thrust_of_destiny,
 ]
 b_pool = weighted_pool(_b_c, _b_u, _b_r)
 brynhild = Hero("Brynhild", 18, bryn_base, b_pool)

--- a/test_sim.py
+++ b/test_sim.py
@@ -526,5 +526,42 @@ class TestMerlinCards(unittest.TestCase):
         sim.resolve_attack(hero, attack, ctx)
         self.assertEqual(enemy.hp, 0)
 
+
+class TestBrynhildCards(unittest.TestCase):
+    def test_hymn_shields_armor_cap(self):
+        hero = sim.Hero("Hero", 10, [])
+        card = sim.hymn_shields
+        enemy = sim.Enemy("Dummy", 1, 5, sim.Element.NONE, [0, 0, 0, 0])
+        ctx = {"enemies": [enemy]}
+        sim.resolve_attack(hero, card, ctx)
+        for fx, e in ctx.get("end_hooks", []):
+            fx(hero, ctx, e)
+        self.assertEqual(hero.armor_pool, 1)
+        for _ in range(4):
+            ctx["end_hooks"] = []
+            sim.apply_persistent(hero, ctx)
+            for fx, e in ctx.get("end_hooks", []):
+                fx(hero, ctx, e)
+        self.assertEqual(hero.armor_pool, 3)
+
+    def test_valkyries_descent_hymn_bonus(self):
+        hero = sim.Hero("Hero", 10, [])
+        hymn = sim.atk("Prayer", sim.CardType.UTIL, 0, hymn=True, persistent="combat")
+        enemy = sim.Enemy("Dummy", 3, 8, sim.Element.NONE, [0, 0, 0, 0])
+        ctx = {"enemies": [enemy]}
+        sim.resolve_attack(hero, hymn, ctx)
+        sim.resolve_attack(hero, sim.valkyrie_descent, ctx)
+        self.assertEqual(enemy.hp, 2)
+
+    def test_thrust_of_destiny_bonus(self):
+        hero = sim.Hero("Hero", 10, [])
+        hymns = [sim.atk("Prayer", sim.CardType.UTIL, 0, hymn=True, persistent="combat") for _ in range(3)]
+        enemy = sim.Enemy("Dummy", 5, 8, sim.Element.NONE, [0, 0, 0, 0])
+        ctx = {"enemies": [enemy]}
+        for h in hymns:
+            sim.resolve_attack(hero, h, ctx)
+        sim.resolve_attack(hero, sim.thrust_of_destiny, ctx)
+        self.assertEqual(enemy.hp, 2)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- expand Brynhild base deck and upgrade pool
- implement Hymn of Shields persistent armor logic
- add Valkyrie's Descent and Thrust of Destiny attacks
- test hymn scaling, armor cap and new cards

## Testing
- `python3 -m unittest`