### PR TITLE
Implement single-miss reroll effect

### DIFF
--- a/sim.py
+++ b/sim.py
@@ -197,6 +197,9 @@ def roll_hits(num_dice: int, defense: int, mod: int = 0, *,
         # initial roll without automatic rerolls
         r = roll_die(defense, mod, hero=hero, allow_reroll=False)
         rerolled = False
+        if r < defense and ctx and ctx.get('reroll_misses_once'):
+            r = max(1, min(8, d8() + mod))
+            rerolled = True
         while r < defense and free_rerolls:
             free_rerolls -= 1
             r = max(1, min(8, d8() + mod))
@@ -332,9 +335,9 @@ def add_rerolls(n: int) -> Callable[[Hero, Dict[str, object]], None]:
     return _fx
 
 def global_reroll_fx() -> Callable[[Hero, Dict[str, object]], None]:
-    """Enable rerolls equal to dice rolled on every attack."""
+    """Reroll each die that misses once for this exchange."""
     def _fx(h: Hero, ctx: Dict[str, object]) -> None:
-        ctx['global_reroll'] = True
+        ctx['reroll_misses_once'] = True
     return _fx
 
 def reroll_per_attack_fx(n: int) -> Callable[[Hero, Dict[str, object]], None]:
@@ -2354,6 +2357,7 @@ def fight_one(hero: Hero) -> bool:
             ctx["hymn_damage"] = 0
             ctx["extra_rerolls"] = 0
             ctx["global_reroll"] = False
+            ctx["reroll_misses_once"] = False
             ctx["exchange_bonus"] = 0
             ctx["attacks_used"] = 0
             ctx["dice_played"] = False

--- a/test_sim.py
+++ b/test_sim.py
@@ -381,6 +381,16 @@ class TestNewCardEffects(unittest.TestCase):
         sim.resolve_attack(hero, attack, ctx)
         self.assertTrue(all(e.hp == 0 for e in enemies))
 
+    def test_global_reroll_fx(self):
+        """Missed dice are rerolled once for the exchange."""
+        sim.RNG.seed(0)
+        hero = sim.Hero("Hero", 10, [])
+        enemy = sim.Enemy("Dummy", 10, 6, sim.Element.NONE, [0, 0, 0, 0])
+        ctx = {"enemies": [enemy]}
+        sim.global_reroll_fx()(hero, ctx)
+        dmg = sim.roll_hits(4, enemy.defense, hero=hero, enemy=enemy, ctx=ctx, allow_reroll=False)
+        self.assertEqual(dmg, 4)
+
 class TestHymnMechanics(unittest.TestCase):
     def test_hymn_armor_scaling(self):
         hero = sim.Hero("Hero", 10, [])


### PR DESCRIPTION
## Summary
- change `global_reroll_fx` so it rerolls each miss once
- support the new flag in `roll_hits`
- clear `reroll_misses_once` each exchange
- test new reroll behaviour

## Testing
- `python3 sim.py`
- `python3 -m pytest -q` *(fails: No module named pytest)*