### PR TITLE
Fix Flowing Water Parry armor

### DIFF
--- a/sim.py
+++ b/sim.py
@@ -1880,7 +1880,7 @@ heaven_earth = atk(
 )
 flowing_water = atk(
     "Flowing Water Parry", CardType.MELEE, 1, Element.SPIRITUAL,
-    armor=1, effect=gain_armor(1), before_ranged=True
+    armor=1, before_ranged=True
 )
 dual_moon_guard = atk(
     "Dual-Moon Guard", CardType.MELEE, 1, Element.DIVINE,


### PR DESCRIPTION
## Summary
- remove extra gain_armor call from Flowing Water Parry so it only provides 1 Armor

## Testing
- `python3 test_basic.py`
- `python3 test_sim.py` *(fails: test_hymn_storms_effect)*
- `python3 -m unittest` *(fails: test_hymn_storms_effect)*