### PR TITLE
Fix Battojutsu Strike armor

### DIFF
--- a/sim.py
+++ b/sim.py
@@ -1987,7 +1987,7 @@ musashi_base = [
 
 battojutsu_strike = atk(
     "Battojutsu Strike", CardType.MELEE, 2, Element.PRECISE,
-    armor=2, effect=gain_armor(2), before_ranged=True
+    armor=1, before_ranged=True
 )
 scroll_cut_slash = atk(
     "Scroll-Cut Slash", CardType.MELEE, 3, Element.PRECISE,


### PR DESCRIPTION
## Summary
- nerf Battojutsu Strike to 1 Armor

## Testing
- `python test_basic.py`
- `python test_sim.py`