### PR TITLE
Implement selective discard damage boost

### DIFF
--- a/sim.py
+++ b/sim.py
@@ -416,14 +416,22 @@ def discard_for_area_damage(mult: int) -> Callable[[Hero, Dict[str, object]], No
     return _fx
 
 def discard_bonus_damage(mult: int) -> Callable[[Hero, Dict[str, object]], None]:
-    """Discard all cards to gain ``mult`` damage per card this attack."""
+    """Discard any number of cards for ``mult`` bonus damage per card."""
+
     def _fx(h: Hero, ctx: Dict[str, object]) -> None:
-        count = len(h.deck.hand)
-        for _ in range(count):
+        if not h.deck.hand:
+            return
+        try:
+            prompt = f"Discard how many cards (0-{len(h.deck.hand)}): "
+            choice = int(input(prompt).strip())
+        except Exception:
+            choice = len(h.deck.hand)
+        n = max(0, min(choice, len(h.deck.hand)))
+        for _ in range(n):
             i = RNG.randrange(len(h.deck.hand))
             h.deck.disc.append(h.deck.hand.pop(i))
-        if count:
-            bonus = mult * count
+        if n:
+            bonus = mult * n
             ctx['bonus_damage'] = ctx.get('bonus_damage', 0) + bonus
             enemy = ctx.get('last_target')
             if isinstance(enemy, Enemy):

--- a/test_sim.py
+++ b/test_sim.py
@@ -691,9 +691,23 @@ class TestHerculesCards(unittest.TestCase):
                        effect=sim.discard_bonus_damage(3))
         enemy = sim.Enemy("Dummy", 6, 1, sim.Element.NONE, [0, 0, 0, 0])
         ctx = {"enemies": [enemy]}
-        sim.resolve_attack(hero, card, ctx)
+        with unittest.mock.patch("builtins.input", return_value="2"):
+            sim.resolve_attack(hero, card, ctx)
         self.assertEqual(enemy.hp, 0)
         self.assertEqual(len(hero.deck.hand), 0)
+
+    def test_bondless_effort_partial_discard(self):
+        sim.RNG.seed(0)
+        hero = sim.Hero("Hero", 10, [])
+        hero.deck.hand = [sim.atk("a", sim.CardType.UTIL, 0) for _ in range(3)]
+        card = sim.atk("Bondless Effort", sim.CardType.MELEE, 0,
+                       effect=sim.discard_bonus_damage(3))
+        enemy = sim.Enemy("Dummy", 3, 1, sim.Element.NONE, [0, 0, 0, 0])
+        ctx = {"enemies": [enemy]}
+        with unittest.mock.patch("builtins.input", return_value="1"):
+            sim.resolve_attack(hero, card, ctx)
+        self.assertEqual(enemy.hp, 0)
+        self.assertEqual(len(hero.deck.hand), 2)
 
     def test_horde_breaker_death_trigger(self):
         sim.RNG.seed(0)


### PR DESCRIPTION
## Summary
- tweak `discard_bonus_damage` to ask how many cards to discard
- update Hercules card tests for new prompt
- add a partial discard test

## Testing
- `python3 -m unittest`