### PR TITLE
Add choice for Fate or Armor

### DIFF
--- a/sim.py
+++ b/sim.py
@@ -1062,17 +1062,26 @@ def misfortunes_muse_fx(hero: Hero, ctx: Dict[str, object]) -> None:
 
 
 def tyrs_choice_fx(hero: Hero, ctx: Dict[str, object]) -> None:
-    if hero.fate <= FATE_MAX - 2:
-        hero.gain_fate(2)
-    else:
+    """Let the player choose to gain 2 Fate or 2 Armor."""
+    try:
+        choice = input("Gain 2 Fate or 2 Armor? (F/A): ").strip().upper()
+    except Exception:
+        choice = ""
+    if choice.startswith("A"):
         hero.armor_pool += 2
+    else:
+        hero.gain_fate(2)
 
 def fortunes_throw_fx(hero: Hero, ctx: Dict[str, object]) -> None:
-    """Gain 2 Fate if not near max, otherwise gain 2 Armor."""
-    if hero.fate <= FATE_MAX - 2:
-        hero.gain_fate(2)
-    else:
+    """Gain 2 Fate or 2 Armor based on player choice."""
+    try:
+        choice = input("Gain 2 Fate or 2 Armor? (F/A): ").strip().upper()
+    except Exception:
+        choice = ""
+    if choice.startswith("A"):
         hero.armor_pool += 2
+    else:
+        hero.gain_fate(2)
 
 
 def norns_gambit_fx(hero: Hero, ctx: Dict[str, object]) -> None:

--- a/test_sim.py
+++ b/test_sim.py
@@ -729,9 +729,21 @@ class TestHerculesCards(unittest.TestCase):
                        effect=sim.fortunes_throw_fx)
         enemy = sim.Enemy("Dummy", 1, 1, sim.Element.NONE, [0, 0, 0, 0])
         ctx = {"enemies": [enemy]}
-        sim.resolve_attack(hero, card, ctx)
+        with unittest.mock.patch("builtins.input", return_value="F"):
+            sim.resolve_attack(hero, card, ctx)
         self.assertEqual(hero.fate, 2)
         self.assertEqual(hero.armor_pool, 0)
+
+    def test_fortunes_throw_armor_choice(self):
+        hero = sim.Hero("Hero", 10, [])
+        card = sim.atk("Fortune", sim.CardType.RANGED, 0,
+                       effect=sim.fortunes_throw_fx)
+        enemy = sim.Enemy("Dummy", 1, 1, sim.Element.NONE, [0, 0, 0, 0])
+        ctx = {"enemies": [enemy]}
+        with unittest.mock.patch("builtins.input", return_value="A"):
+            sim.resolve_attack(hero, card, ctx)
+        self.assertEqual(hero.fate, 0)
+        self.assertEqual(hero.armor_pool, 2)
 
     def test_true_might_first_dice_attack_bonus(self):
         """True Might deals 8 bonus damage when played before any dice cards."""


### PR DESCRIPTION
## Summary
- ask player to pick 2 Fate or 2 Armor for Tyr's Choice and Fortune's Throw
- mock input in tests for Fortune's Throw
- add test for armor option

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*