### PR TITLE
Add card win/loss tracking

### DIFF
--- a/stats_runner.py
+++ b/stats_runner.py
@@ -48,12 +48,16 @@ def run_gauntlet(hero: sim.Hero) -> bool:
 def run_stats(num_runs: int = 50000) -> Dict[str, int]:
     """Run ``num_runs`` gauntlets for each hero and return win counts."""
     results: Dict[str, int] = {h.name: 0 for h in sim.HEROES}
-    for proto in sim.HEROES:
-        for _ in range(num_runs):
-            hero = sim.Hero(proto.name, proto.max_hp, proto.base_cards[:],
-                            proto._orig_pool[:])
-            if run_gauntlet(hero):
-                results[proto.name] += 1
+    sim.AUTO_MODE = True
+    try:
+        for proto in sim.HEROES:
+            for _ in range(num_runs):
+                hero = sim.Hero(proto.name, proto.max_hp, proto.base_cards[:],
+                                proto._orig_pool[:])
+                if run_gauntlet(hero):
+                    results[proto.name] += 1
+    finally:
+        sim.AUTO_MODE = False
     return results
 
 if __name__ == "__main__":

--- a/test_card_stats.py
+++ b/test_card_stats.py
@@ -1,0 +1,17 @@
+import unittest
+import sim
+
+class TestCardStats(unittest.TestCase):
+    def test_correlation_tracking(self):
+        sim.RNG.seed(0)
+        hero = sim.Hero("Hercules", 25, sim.herc_base, sim.herc_pool)
+        sim.fight_one(hero)
+        data = sim.get_card_correlations()
+        self.assertIn("Hercules", data)
+        buckets = data["Hercules"]
+        self.assertTrue(any(buckets[r] for r in buckets))
+        total = sum(v["win"] + v["loss"] for cat in buckets.values() for v in cat.values())
+        self.assertGreater(total, 0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- record draws and plays per hero deck
- aggregate win/loss counts for each card
- expose `get_card_correlations` for later reporting
- support non-interactive stats runs
- test card correlation tracking

## Testing
- `python -m unittest test_basic.py test_sim.py test_card_stats.py test_stats_runner.py -v`