### PR TITLE
Track per-enemy damage in monster_attack

### DIFF
--- a/test_sim.py
+++ b/test_sim.py
@@ -251,6 +251,26 @@ class TestMinotaurAbilities(unittest.TestCase):
         self.assertEqual(hero.hp, 2)
 
 
+class TestMonsterDamageTracking(unittest.TestCase):
+    def test_damage_logged(self):
+        sim.MONSTER_DAMAGE.clear()
+        hero = sim.Hero("Hero", 10, [])
+        enemy = sim.Enemy("Goblin", 1, 1, sim.Element.NONE, [1, 1, 1, 1])
+        ctx = {"enemies": [enemy]}
+        sim.monster_attack([hero], ctx)
+        self.assertEqual(sim.MONSTER_DAMAGE[(hero.name, enemy.name)], 1)
+
+    def test_counters_reset_between_runs(self):
+        sim.MONSTER_DAMAGE.clear()
+        hero = sim.Hero("Hero", 10, [])
+        enemy = sim.Enemy("Dummy", 1, 1, sim.Element.NONE, [1, 1, 1, 1])
+        ctx = {"enemies": [enemy]}
+        sim.monster_attack([hero], ctx)
+        self.assertIn((hero.name, enemy.name), sim.MONSTER_DAMAGE)
+        sim.fight_one(sim.Hero("Hero", 10, []))
+        self.assertNotIn((hero.name, enemy.name), sim.MONSTER_DAMAGE)
+
+
 class TestBansheeAbilities(unittest.TestCase):
     def test_ghostly_clears_on_fourth_exchange(self):
         enemy = sim.Enemy(


### PR DESCRIPTION
## Summary
- record damage done by each enemy to every hero
- expose monster damage stats via `get_monster_damage`
- clear monster damage counters when starting a new run
- test monster damage accounting and reset

## Testing
- `python3 -m unittest discover -q`
- `python3 -m unittest test_sim.TestMonsterDamageTracking -v`