### PR TITLE
Add enemy run statistics

### DIFF
--- a/test_enemy_stats.py
+++ b/test_enemy_stats.py
@@ -1,0 +1,34 @@
+import unittest
+import sim
+
+class TestEnemyRunStats(unittest.TestCase):
+    def test_run_counts(self):
+        old_auto = sim.AUTO_MODE
+        sim.AUTO_MODE = True
+        sim.ENEMY_RUN_COUNTS.clear()
+        # add easy enemies
+        sim.ENEMIES['Easy'] = sim.Enemy('Easy', 1, 1, sim.Element.NONE, [0,0,0,0])
+        sim.ENEMIES['Elite Easy'] = sim.Enemy('Elite Easy', 1, 1, sim.Element.NONE, [0,0,0,0])
+        original = sim.ENEMY_WAVES
+        try:
+            sim.ENEMY_WAVES = [('Easy',1), ('Elite Easy',1)]
+            hero = sim.Hero('Hero', 10, [sim.atk('Hit', sim.CardType.MELEE, 5)], [])
+            sim.RNG.seed(0)
+            self.assertTrue(sim.fight_one(hero))
+
+            sim.ENEMY_WAVES = [('Elite Easy',1)]
+            hero2 = sim.Hero('Hero', 1, [sim.atk('Hit', sim.CardType.MELEE, 0)], [])
+            sim.RNG.seed(0)
+            self.assertFalse(sim.fight_one(hero2))
+        finally:
+            sim.ENEMY_WAVES = original
+            sim.AUTO_MODE = old_auto
+
+        stats = sim.get_enemy_run_counts()
+        self.assertEqual(stats['Easy']['common']['win'], 1)
+        self.assertEqual(stats['Easy']['common']['loss'], 0)
+        self.assertEqual(stats['Easy']['elite']['win'], 1)
+        self.assertEqual(stats['Easy']['elite']['loss'], 1)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- track how often each enemy type appears in successful or failed runs
- expose `get_enemy_run_counts` for aggregated results
- update `fight_one` to record enemy appearances for each run
- test that enemy statistics accumulate separately for common and elite variants

## Testing
- `python3 -m unittest discover -v`