### PR TITLE
Track enemy appearances per hero

### DIFF
--- a/stats_runner.py
+++ b/stats_runner.py
@@ -124,14 +124,16 @@ def format_report(wins: Dict[str, int], card_data: dict, damage: dict,
             lines.append(f"  {enemy}: {val}")
 
     lines.append("\n=== Enemy Appearance Outcomes ===")
-    for enemy in sorted(enemy_data):
-        lines.append(f"{enemy}:")
-        for variant in ("common", "elite"):
-            stats = enemy_data[enemy][variant]
-            total = stats["win"] + stats["loss"]
-            pct = (stats["win"] / total * 100) if total else 0.0
-            lines.append(
-                f"  {variant}: {pct:.1f}% win ({stats['win']}/{total})")
+    for hero in sorted(enemy_data):
+        lines.append(f"{hero}:")
+        for enemy in sorted(enemy_data[hero]):
+            lines.append(f"  {enemy}:")
+            for variant in ("common", "elite"):
+                stats = enemy_data[hero][enemy][variant]
+                total = stats["win"] + stats["loss"]
+                pct = (stats["win"] / total * 100) if total else 0.0
+                lines.append(
+                    f"    {variant}: {pct:.1f}% win ({stats['win']}/{total})")
 
     return "\n".join(lines)
 

--- a/test_enemy_stats.py
+++ b/test_enemy_stats.py
@@ -25,10 +25,10 @@ class TestEnemyRunStats(unittest.TestCase):
             sim.AUTO_MODE = old_auto
 
         stats = sim.get_enemy_run_counts()
-        self.assertEqual(stats['Easy']['common']['win'], 1)
-        self.assertEqual(stats['Easy']['common']['loss'], 0)
-        self.assertEqual(stats['Easy']['elite']['win'], 1)
-        self.assertEqual(stats['Easy']['elite']['loss'], 1)
+        self.assertEqual(stats['Hero']['Easy']['common']['win'], 1)
+        self.assertEqual(stats['Hero']['Easy']['common']['loss'], 0)
+        self.assertEqual(stats['Hero']['Easy']['elite']['win'], 1)
+        self.assertEqual(stats['Hero']['Easy']['elite']['loss'], 1)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_run_counters.py
+++ b/test_run_counters.py
@@ -20,8 +20,12 @@ class TestSimulationCounters(unittest.TestCase):
         # enemy appearance/run counts updated
         enemy_stats = sim.get_enemy_run_counts()
         self.assertEqual(
-            enemy_stats["Treant"],
-            {"common": {"win": 0, "loss": 2}, "elite": {"win": 0, "loss": 3}},
+            enemy_stats["Hercules"]["Treant"],
+            {"common": {"win": 0, "loss": 2}, "elite": {"win": 0, "loss": 1}},
+        )
+        self.assertEqual(
+            enemy_stats["Brynhild"]["Treant"],
+            {"common": {"win": 0, "loss": 0}, "elite": {"win": 0, "loss": 2}},
         )
 
         # total damage inflicted by a specific enemy is tracked


### PR DESCRIPTION
## Summary
- update ENEMY_RUN_COUNTS to include hero name
- record enemy runs for a specific hero
- update enemy run retrieval and stats report formatting
- adjust calls and tests for hero-specific enemy data

## Testing
- `python -m unittest`