### PR TITLE
Ensure damage counters reset between stats runs

### DIFF
--- a/stats_runner.py
+++ b/stats_runner.py
@@ -87,6 +87,7 @@ def run_stats_with_damage(num_runs: int = 50000) -> tuple[Dict[str, int], dict]:
                     damage[key] += val
     finally:
         sim.AUTO_MODE = False
+    sim.MONSTER_DAMAGE.clear()
     return results, damage
 
 

--- a/test_run_counters.py
+++ b/test_run_counters.py
@@ -31,5 +31,13 @@ class TestSimulationCounters(unittest.TestCase):
         # total damage inflicted by a specific enemy is tracked
         self.assertEqual(damage[("Hercules", "Elite Minotaur")], 9)
 
+    def test_damage_reset_between_runs(self):
+        """MONSTER_DAMAGE should be empty when a new stats run begins."""
+        sim.RNG.seed(1)
+        stats_runner.run_stats_with_damage(num_runs=1)
+        self.assertEqual(sim.MONSTER_DAMAGE, {})
+        stats_runner.run_stats_with_damage(num_runs=1)
+        self.assertEqual(sim.MONSTER_DAMAGE, {})
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- clear `sim.MONSTER_DAMAGE` at the end of `run_stats_with_damage`
- add regression test to ensure damage counters reset between consecutive calls

## Testing
- `python -m unittest discover -v`