### PR TITLE
Handle enemy removal in pre effect

### DIFF
--- a/sim.py
+++ b/sim.py
@@ -2376,6 +2376,9 @@ def resolve_attack(hero: Hero, card: Card, ctx: Dict[str, object]) -> None:
                 hero.combat_effects.append((card.effect, card))
             elif card.persistent == "exchange":
                 hero.exchange_effects.append((card.effect, card))
+        enemies = ctx["enemies"]
+        if not enemies:
+            return
     if card.multi:
         if card.max_targets is None:
             targets = enemies[:]

--- a/test_sim.py
+++ b/test_sim.py
@@ -727,6 +727,18 @@ class TestHerculesCards(unittest.TestCase):
         self.assertEqual(enemy.hp, 0)
         self.assertEqual(len(hero.deck.hand), 2)
 
+    def test_pre_effect_kills_enemy(self):
+        """Pre effects that kill should end the attack without errors."""
+        sim.RNG.seed(0)
+        hero = sim.Hero("Hero", 10, [])
+        hero.deck.hand = [sim.atk("a", sim.CardType.UTIL, 0)]
+        card = sim.atk("Prep", sim.CardType.MELEE, 1,
+                       effect=sim.discard_bonus_damage(3), pre=True)
+        enemy = sim.Enemy("Dummy", 3, 1, sim.Element.NONE, [0, 0, 0, 0])
+        ctx = {"enemies": [enemy]}
+        sim.resolve_attack(hero, card, ctx)
+        self.assertFalse(ctx["enemies"])  # enemy defeated by pre effect
+
     def test_horde_breaker_death_trigger(self):
         sim.RNG.seed(0)
         hero = sim.Hero("Hero", 10, [])


### PR DESCRIPTION
## Summary
- exit resolve_attack early if pre effect removed all enemies
- add regression test for pre-effect lethal damage

## Testing
- `python3 -m unittest -q`