### PR TITLE
Add CLI wrapper for stats

### DIFF
--- a/run_stats.py
+++ b/run_stats.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Command line interface for stats_runner.generate_report."""
+"""Run the full statistics report for the card game simulator.
+
+Running this module executes :func:`stats_runner.generate_report` with a
+default of 50,000 simulated runs.  The number of runs may be overridden via
+the ``--runs`` command line argument.
+"""
 
 import argparse
 import stats_runner


### PR DESCRIPTION
## Summary
- add documentation to `run_stats.py` and ensure it exposes a small CLI

## Testing
- `python3 run_stats.py --runs 1 | head`