### PR TITLE
Add HP logging during gauntlets

### DIFF
--- a/sim.py
+++ b/sim.py
@@ -2582,8 +2582,17 @@ def monster_attack(heroes: List[Hero], ctx: Dict[str, object]) -> None:
 
 # very small fight simulation -------------------------------------------------
 
-def fight_one(hero: Hero) -> bool:
-    """Run one full gauntlet for ``hero``."""
+def fight_one(hero: Hero, hp_log: list[int] | None = None) -> bool:
+    """Run one full gauntlet for ``hero``.
+
+    Parameters
+    ----------
+    hero:
+        The :class:`Hero` to run through the gauntlet.
+    hp_log:
+        Optional list that, if provided, receives the hero's remaining hit
+        points after each completed wave.
+    """
 
     MONSTER_DAMAGE.clear()
     hero.reset()
@@ -2709,6 +2718,9 @@ def fight_one(hero: Hero) -> bool:
             _record_run_result(hero, False)
             _record_enemy_run(hero.name, run_waves, False)
             return False
+
+        if hp_log is not None:
+            hp_log.append(hero.hp)
 
         hero.gain_upgrades(1)
         hero.gain_fate(1)

--- a/test_run_counters.py
+++ b/test_run_counters.py
@@ -5,7 +5,7 @@ import stats_runner
 class TestSimulationCounters(unittest.TestCase):
     def test_run_stats_aggregates(self):
         sim.RNG.seed(0)
-        wins, damage = stats_runner.run_stats_with_damage(num_runs=3)
+        wins, damage, hp = stats_runner.run_stats_with_damage(num_runs=3)
         # win counters should record a loss for each hero
         expected_wins = {h.name: 0 for h in sim.HEROES}
         self.assertEqual(wins, expected_wins)

--- a/test_stats_runner.py
+++ b/test_stats_runner.py
@@ -11,5 +11,15 @@ class TestStatsRunner(unittest.TestCase):
         for val in results.values():
             self.assertTrue(0 <= val <= 5)
 
+    def test_run_stats_with_hp(self):
+        sim.RNG.seed(1)
+        wins, damage, hp = stats_runner.run_stats_with_damage(num_runs=1)
+        hero_names = {h.name for h in sim.HEROES}
+        self.assertEqual(set(hp.keys()), hero_names)
+        for vals in hp.values():
+            self.assertEqual(len(vals), 8)
+            for v in vals:
+                self.assertTrue(0 <= v <= 100)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- record hero HP after each wave when running a gauntlet
- expose HP logs through `run_stats_with_damage`
- print HP averages in reports
- test that HP averages are returned

## Testing
- `python -m unittest discover -v`