### PR TITLE
Fix HP aggregation and add early death test

### DIFF
--- a/stats_runner.py
+++ b/stats_runner.py
@@ -74,7 +74,10 @@ def run_stats(num_runs: int = 50000) -> Dict[str, int]:
 
 
 def run_stats_with_damage(num_runs: int = 50000) -> tuple[Dict[str, int], dict, dict]:
-    """Run gauntlets collecting win counts, damage and HP progression."""
+    """Run gauntlets collecting win counts, damage and HP progression.
+
+    When aggregating HP values, uncompleted waves are counted as 0 HP.
+    """
     from collections import defaultdict
 
     results: Dict[str, int] = {h.name: 0 for h in sim.HEROES}
@@ -95,7 +98,8 @@ def run_stats_with_damage(num_runs: int = 50000) -> tuple[Dict[str, int], dict, 
                 hp_log: list[int] = []
                 if run_gauntlet(hero, hp_log):
                     results[proto.name] += 1
-                for idx, hp in enumerate(hp_log):
+                for idx in range(8):
+                    hp = hp_log[idx] if idx < len(hp_log) else 0
                     hp_totals[proto.name][idx] += hp
                     hp_counts[proto.name][idx] += 1
                 for key, val in sim.get_monster_damage().items():

--- a/test_stats_runner.py
+++ b/test_stats_runner.py
@@ -21,5 +21,17 @@ class TestStatsRunner(unittest.TestCase):
             for v in vals:
                 self.assertTrue(0 <= v <= 100)
 
+    def test_hp_log_fills_zeros_after_death(self):
+        """HP logs should contain zeros after an early death."""
+        sim.RNG.seed(0)
+        _, _, hp = stats_runner.run_stats_with_damage(num_runs=1)
+        vals = hp.get("Hercules")
+        self.assertIsNotNone(vals)
+        self.assertEqual(len(vals), 8)
+        for v in vals:
+            self.assertTrue(0 <= v <= 100)
+        # hero dies early so later waves should be zero
+        self.assertTrue(any(v == 0 for v in vals[1:]))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- document that `run_stats_with_damage` counts missing waves as 0 HP
- ensure HP totals account for missing waves
- test HP aggregation when a hero dies early

## Testing
- `python -m unittest discover -v`