### PR TITLE
Remove fixed exchange limit

### DIFF
--- a/DESIGN_REFERENCE.md
+++ b/DESIGN_REFERENCE.md
@@ -3,7 +3,7 @@
 This document consolidates all gameplay data, card lists, enemy stats and outstanding features for the board game simulator. Use it as a comprehensive reference when implementing or expanding the code.
 
 ## Gameplay Overview
-- Heroes play through a series of **waves** of enemies. Each wave lasts up to four exchanges.
+- Heroes play through a series of **waves** of enemies. Each wave continues until all foes are defeated or the hero can no longer draw cards.
 - Cards resolve in the order: **Utility ➜ Ranged ➜ Monster attacks ➜ delayed Ranged ➜ Melee**.
 - After an exchange, end-of-exchange effects trigger and the hero draws a card.
 - After defeating a wave the hero gains 1 Fate, draws 3 cards and chooses one upgrade from their pool.
@@ -227,7 +227,7 @@ This file summarises the intended card sets, enemy stats and gameplay rules for 
 - **Armor** absorbs damage before HP.
 - **Hymns** (Brynhild) provide persistent buffs lasting an exchange or combat.
 - Attacks can be Brutal (B), Precise (P), Divine (D), Arcane (A) or Spiritual (S). Matching the enemy's vulnerability doubles damage.
-- Combat proceeds in waves. Each wave plays up to four exchanges where cards resolve in the order: Utility → Ranged → monster attacks → delayed Ranged → Melee. After each exchange, end‑of‑exchange effects trigger and the hero draws a card.
+- Combat proceeds in waves. Exchanges repeat in the order: Utility → Ranged → monster attacks → delayed Ranged → Melee. After each exchange, end‑of‑exchange effects trigger and the hero draws based on the number of attacks played. The wave ends when all enemies fall, the hero dies or no further cards can be drawn.
 - After a wave the hero gains 1 Fate, draws 3 cards and chooses an upgrade from a weighted pool: 3 copies of each common, 2 of each uncommon, 1 of each rare.
 
 ## Card Catalogues

--- a/sim.py
+++ b/sim.py
@@ -2602,7 +2602,11 @@ def fight_one(hero: Hero, hp_log: list[int] | None = None) -> bool:
     for name, count in ENEMY_WAVES:
         ctx = make_wave(name, count)
         ctx["heroes"] = [hero]
-        for exch in range(4):
+        exch = 0
+        ctx["next_draw"] = 1
+        while True:
+            if not hero.deck.hand and ctx.get("next_draw", 1) == 0:
+                break
             ctx["exchange"] = exch
             # remove any lingering exchange effects and hymns from the previous
             # round before applying persistent buffs
@@ -2710,9 +2714,14 @@ def fight_one(hero: Hero, hp_log: list[int] | None = None) -> bool:
             if not ctx["enemies"]:
                 break
 
-            draw_amt = max(0, 1 - ctx.get("draw_penalty", 0))
+            draw_amt = max(
+                0,
+                ctx.get("attacks_used", 0) - 1 - ctx.get("draw_penalty", 0),
+            )
             if draw_amt:
                 hero.deck.draw(draw_amt)
+            ctx["next_draw"] = draw_amt
+            exch += 1
 
         if ctx["enemies"] or hero.hp <= 0:
             _record_run_result(hero, False)


### PR DESCRIPTION
## Summary
- remove hard-coded 4 exchange loop and use dynamic while loop in `fight_one`
- track draw amount per exchange with `ctx["next_draw"]`
- update draw logic to depend on attacks used
- document new endless-exchange behaviour in `DESIGN_REFERENCE.md`

## Testing
- `python3 -m py_compile sim.py`
- `python3 -m pytest -q` *(fails: No module named pytest)*