### PR TITLE
Add progress reporting feature

### DIFF
--- a/Full_Simulation.py
+++ b/Full_Simulation.py
@@ -11,9 +11,12 @@ def main() -> None:
     parser.add_argument(
         "--runs", type=int, default=50000,
         help="Number of gauntlet runs to simulate")
+    parser.add_argument(
+        "--progress", action="store_true",
+        help="Display simulation progress")
     args = parser.parse_args()
 
-    report = stats_runner.generate_report(num_runs=args.runs)
+    report = stats_runner.generate_report(num_runs=args.runs, progress=args.progress)
     print(report)
 
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ be adjusted with the `--runs` option:
 python3 run_stats.py --runs 10000
 ```
 
+Passing `--progress` prints periodic updates with the current hero,
+percentage complete and an estimated time remaining.
+
 The output begins with a win‑rate summary similar to the following:
 
 ```text

--- a/herc_merlin_musashi_balancer.py
+++ b/herc_merlin_musashi_balancer.py
@@ -367,6 +367,7 @@ def optimise():
     best_B  = [w.enemy.band[:] for w in WAVES]
     best_err = float('inf')
     last_improve = time.time()
+    start = last_improve
 
     T = 1.0           # initial “temperature” for simulated annealing
     cool = 0.997      # cooling factor
@@ -431,6 +432,9 @@ def optimise():
             cool = 1.0
 
         gen += 1
+        if gen % 1000 == 0:
+            elapsed = time.time() - start
+            print(f"Generation {gen} - elapsed {int(elapsed)}s")
 
     # final dump
     print("\nBest error:", best_err)

--- a/run_stats.py
+++ b/run_stats.py
@@ -15,9 +15,12 @@ def main() -> None:
     parser.add_argument(
         "--runs", type=int, default=50000,
         help="Number of gauntlet runs to simulate")
+    parser.add_argument(
+        "--progress", action="store_true",
+        help="Display simulation progress")
     args = parser.parse_args()
 
-    report = stats_runner.generate_report(num_runs=args.runs)
+    report = stats_runner.generate_report(num_runs=args.runs, progress=args.progress)
     print(report)
 
 


### PR DESCRIPTION
## Summary
- show simulation progress in `run_stats` and `run_stats_with_damage`
- allow progress printing in `generate_report`
- expose `--progress` flag in `run_stats.py` and `Full_Simulation.py`
- document the flag in the README
- print periodic status from the optimisation script

## Testing
- `python3 -m unittest discover -v`