### PR TITLE
Add exchange limit to fight_one

### DIFF
--- a/sim.py
+++ b/sim.py
@@ -2583,7 +2583,8 @@ def monster_attack(heroes: List[Hero], ctx: Dict[str, object]) -> None:
 
 # very small fight simulation -------------------------------------------------
 
-def fight_one(hero: Hero, hp_log: list[int] | None = None, *, timeout: float | None = None) -> bool:
+def fight_one(hero: Hero, hp_log: list[int] | None = None, *, timeout: float | None = None,
+              max_exchanges: int | None = 1000) -> bool:
     """Run one full gauntlet for ``hero``.
 
     Parameters
@@ -2593,6 +2594,10 @@ def fight_one(hero: Hero, hp_log: list[int] | None = None, *, timeout: float | N
     hp_log:
         Optional list that, if provided, receives the hero's remaining hit
         points after each completed wave.
+    max_exchanges:
+        Abort a wave with :class:`TimeoutError` if this many exchanges are
+        reached. The default of ``1000`` serves as a safeguard against runaway
+        loops.
     """
 
     MONSTER_DAMAGE.clear()
@@ -2607,6 +2612,9 @@ def fight_one(hero: Hero, hp_log: list[int] | None = None, *, timeout: float | N
         exch = 0
         ctx["next_draw"] = 1
         while True:
+            if max_exchanges is not None and exch >= max_exchanges:
+                raise TimeoutError(
+                    f"{hero.name} timed out on wave {name}")
             if timeout is not None and time.time() - start > timeout:
                 raise TimeoutError(
                     f"{hero.name} timed out on wave {name}")

--- a/test_stats_runner.py
+++ b/test_stats_runner.py
@@ -43,6 +43,15 @@ class TestStatsRunner(unittest.TestCase):
         self.assertIn("Hercules", msg)
         self.assertIn(sim.ENEMY_WAVES[0][0], msg)
 
+    def test_fight_one_max_exchanges(self):
+        sim.RNG.seed(0)
+        hero = sim.Hero("Hercules", 25, sim.herc_base, sim.herc_pool)
+        with self.assertRaises(TimeoutError) as ctx:
+            sim.fight_one(hero, max_exchanges=0)
+        msg = str(ctx.exception)
+        self.assertIn("Hercules", msg)
+        self.assertIn(sim.ENEMY_WAVES[0][0], msg)
+
     def test_run_gauntlet_retries_on_timeout(self):
         hero = sim.Hero("Hercules", 25, sim.herc_base, sim.herc_pool)
         calls = {"n": 0}


### PR DESCRIPTION
## Summary
- allow specifying a max_exchanges limit to `fight_one`
- raise `TimeoutError` when the limit is reached
- document the new parameter and add regression test

## Testing
- `pytest -q` *(fails: command not found)*