### PR TITLE
Add retry and exchange CLI options

### DIFF
--- a/Full_Simulation.py
+++ b/Full_Simulation.py
@@ -2,29 +2,49 @@
 """Unified simulation entry point for the card game."""
 
 import argparse
+
 import stats_runner
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Run full board game simulation statistics")
+        description="Run full board game simulation statistics"
+    )
     parser.add_argument(
-        "--runs", type=int, default=50000,
-        help="Number of gauntlet runs to simulate")
+        "--runs", type=int, default=50000, help="Number of gauntlet runs to simulate"
+    )
     parser.add_argument(
-        "--progress", action="store_true",
-        help="Display simulation progress")
+        "--progress", action="store_true", help="Display simulation progress"
+    )
     parser.add_argument(
-        "--timeout", type=float, default=60.0,
-        help="Maximum seconds to allow per gauntlet run")
+        "--timeout",
+        type=float,
+        default=60.0,
+        help="Maximum seconds to allow per gauntlet run",
+    )
+    parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=5,
+        help="Number of consecutive timeouts to tolerate before aborting",
+    )
+    parser.add_argument(
+        "--max-exchanges",
+        type=int,
+        default=1000,
+        help="Abort a wave after this many exchanges",
+    )
     args = parser.parse_args()
 
-    report = stats_runner.generate_report(num_runs=args.runs,
-                                          progress=args.progress,
-                                          timeout=args.timeout)
+    report = stats_runner.generate_report(
+        num_runs=args.runs,
+        progress=args.progress,
+        timeout=args.timeout,
+        max_retries=args.max_retries,
+        max_exchanges=args.max_exchanges,
+    )
     print(report)
 
 
 if __name__ == "__main__":
     main()
-

--- a/run_stats.py
+++ b/run_stats.py
@@ -3,29 +3,50 @@
 
 Running this module executes :func:`stats_runner.generate_report` with a
 default of 50,000 simulated runs.  The number of runs may be overridden via
-the ``--runs`` command line argument.
+the ``--runs`` command line argument.  Additional options are available to
+limit retries and exchanges per wave.
 """
 
 import argparse
+
 import stats_runner
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run gauntlet statistics")
     parser.add_argument(
-        "--runs", type=int, default=50000,
-        help="Number of gauntlet runs to simulate")
+        "--runs", type=int, default=50000, help="Number of gauntlet runs to simulate"
+    )
     parser.add_argument(
-        "--progress", action="store_true",
-        help="Display simulation progress")
+        "--progress", action="store_true", help="Display simulation progress"
+    )
     parser.add_argument(
-        "--timeout", type=float, default=60.0,
-        help="Maximum seconds to allow per gauntlet run")
+        "--timeout",
+        type=float,
+        default=60.0,
+        help="Maximum seconds to allow per gauntlet run",
+    )
+    parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=5,
+        help="Number of consecutive timeouts to tolerate before aborting",
+    )
+    parser.add_argument(
+        "--max-exchanges",
+        type=int,
+        default=1000,
+        help="Abort a wave after this many exchanges",
+    )
     args = parser.parse_args()
 
-    report = stats_runner.generate_report(num_runs=args.runs,
-                                          progress=args.progress,
-                                          timeout=args.timeout)
+    report = stats_runner.generate_report(
+        num_runs=args.runs,
+        progress=args.progress,
+        timeout=args.timeout,
+        max_retries=args.max_retries,
+        max_exchanges=args.max_exchanges,
+    )
     print(report)
 
 

--- a/stats_runner.py
+++ b/stats_runner.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from typing import Dict
 import argparse
 import time
+from typing import Dict
 
 import sim
 
@@ -13,6 +13,7 @@ import sim
 RNG = sim.RNG
 
 # helper to choose waves -------------------------------------------------------
+
 
 def _select_waves() -> list[tuple[str, int]]:
     """Pick 4 normal and 4 elite groups at random."""
@@ -22,15 +23,18 @@ def _select_waves() -> list[tuple[str, int]]:
     RNG.shuffle(waves)
     return waves
 
+
 # single run ------------------------------------------------------------------
 
+
 def run_gauntlet(
-        hero: sim.Hero,
-        hp_log: list[int] | None = None,
-        *,
-        timeout: float = 60.0,
-        max_retries: int = 5,
-        max_exchanges: int | None = 1000) -> bool:
+    hero: sim.Hero,
+    hp_log: list[int] | None = None,
+    *,
+    timeout: float = 60.0,
+    max_retries: int = 5,
+    max_exchanges: int | None = 1000,
+) -> bool:
     """Run one gauntlet for ``hero`` using random waves and upgrade schedule.
 
     Parameters
@@ -60,24 +64,27 @@ def run_gauntlet(
         sim.ENEMY_WAVES = _select_waves()
         hero.gain_upgrades = patched
         try:
-            return sim.fight_one(hero, hp_log, timeout=timeout,
-                                max_exchanges=max_exchanges)
+            return sim.fight_one(
+                hero, hp_log, timeout=timeout, max_exchanges=max_exchanges
+            )
         except TimeoutError as exc:
             waves = [w for w, _ in sim.ENEMY_WAVES]
             print(f"Timeout after {timeout}s: {hero.name} vs {waves} - {exc}")
             retries += 1
             if retries > max_retries:
-                raise TimeoutError(
-                    f"{hero.name} gauntlet failed repeatedly") from exc
-            hero = sim.Hero(hero.name, hero.max_hp, hero.base_cards[:],
-                            hero._orig_pool[:])
+                raise TimeoutError(f"{hero.name} gauntlet failed repeatedly") from exc
+            hero = sim.Hero(
+                hero.name, hero.max_hp, hero.base_cards[:], hero._orig_pool[:]
+            )
             if hp_log is not None:
                 hp_log.clear()
         finally:
             hero.gain_upgrades = orig_gain
             sim.ENEMY_WAVES = original_waves
 
+
 # bulk stats ------------------------------------------------------------------
+
 
 def _format_eta(seconds: float) -> str:
     seconds = int(seconds)
@@ -90,9 +97,14 @@ def _format_eta(seconds: float) -> str:
     return f"{s}s"
 
 
-def run_stats(num_runs: int = 50000, *, progress: bool = False,
-              timeout: float = 60.0, max_retries: int = 5,
-              max_exchanges: int | None = 1000) -> Dict[str, int]:
+def run_stats(
+    num_runs: int = 50000,
+    *,
+    progress: bool = False,
+    timeout: float = 60.0,
+    max_retries: int = 5,
+    max_exchanges: int | None = 1000,
+) -> Dict[str, int]:
     """Run ``num_runs`` gauntlets for each hero and return win counts.
 
     Parameters
@@ -120,24 +132,40 @@ def run_stats(num_runs: int = 50000, *, progress: bool = False,
     try:
         for proto in sim.HEROES:
             for _ in range(num_runs):
-                hero = sim.Hero(proto.name, proto.max_hp, proto.base_cards[:],
-                                proto._orig_pool[:])
-                if run_gauntlet(hero, timeout=timeout, max_retries=max_retries,
-                                max_exchanges=max_exchanges):
+                hero = sim.Hero(
+                    proto.name, proto.max_hp, proto.base_cards[:], proto._orig_pool[:]
+                )
+                if run_gauntlet(
+                    hero,
+                    timeout=timeout,
+                    max_retries=max_retries,
+                    max_exchanges=max_exchanges,
+                ):
                     results[proto.name] += 1
                 count += 1
                 if progress and (count % step == 0 or count == total):
                     pct = count / total * 100
-                    eta = _format_eta((time.time() - start) * (100 / pct - 1)) if pct else "?"
-                    print(f"Simulating {proto.name} {count}/{total} ({pct:.1f}% - ETA {eta})")
+                    eta = (
+                        _format_eta((time.time() - start) * (100 / pct - 1))
+                        if pct
+                        else "?"
+                    )
+                    print(
+                        f"Simulating {proto.name} {count}/{total} ({pct:.1f}% - ETA {eta})"
+                    )
     finally:
         sim.AUTO_MODE = False
     return results
 
 
-def run_stats_with_damage(num_runs: int = 50000, *, progress: bool = False,
-                          timeout: float = 60.0, max_retries: int = 5,
-                          max_exchanges: int | None = 1000) -> tuple[Dict[str, int], dict, dict]:
+def run_stats_with_damage(
+    num_runs: int = 50000,
+    *,
+    progress: bool = False,
+    timeout: float = 60.0,
+    max_retries: int = 5,
+    max_exchanges: int | None = 1000,
+) -> tuple[Dict[str, int], dict, dict]:
     """Run gauntlets collecting win counts, damage and HP progression.
 
     Parameters
@@ -159,8 +187,8 @@ def run_stats_with_damage(num_runs: int = 50000, *, progress: bool = False,
 
     results: Dict[str, int] = {h.name: 0 for h in sim.HEROES}
     damage: dict = defaultdict(int)
-    hp_totals: dict[str, list[int]] = {h.name: [0]*8 for h in sim.HEROES}
-    hp_counts: dict[str, list[int]] = {h.name: [0]*8 for h in sim.HEROES}
+    hp_totals: dict[str, list[int]] = {h.name: [0] * 8 for h in sim.HEROES}
+    hp_counts: dict[str, list[int]] = {h.name: [0] * 8 for h in sim.HEROES}
 
     sim.CARD_CORRELATIONS.clear()
     sim.ENEMY_RUN_COUNTS.clear()
@@ -174,12 +202,17 @@ def run_stats_with_damage(num_runs: int = 50000, *, progress: bool = False,
     try:
         for proto in sim.HEROES:
             for _ in range(num_runs):
-                hero = sim.Hero(proto.name, proto.max_hp, proto.base_cards[:],
-                                proto._orig_pool[:])
+                hero = sim.Hero(
+                    proto.name, proto.max_hp, proto.base_cards[:], proto._orig_pool[:]
+                )
                 hp_log: list[int] = []
-                if run_gauntlet(hero, hp_log, timeout=timeout,
-                                max_retries=max_retries,
-                                max_exchanges=max_exchanges):
+                if run_gauntlet(
+                    hero,
+                    hp_log,
+                    timeout=timeout,
+                    max_retries=max_retries,
+                    max_exchanges=max_exchanges,
+                ):
                     results[proto.name] += 1
                 for idx in range(8):
                     hp = hp_log[idx] if idx < len(hp_log) else 0
@@ -190,8 +223,14 @@ def run_stats_with_damage(num_runs: int = 50000, *, progress: bool = False,
                 count += 1
                 if progress and (count % step == 0 or count == total):
                     pct = count / total * 100
-                    eta = _format_eta((time.time() - start) * (100 / pct - 1)) if pct else "?"
-                    print(f"Simulating {proto.name} {count}/{total} ({pct:.1f}% - ETA {eta})")
+                    eta = (
+                        _format_eta((time.time() - start) * (100 / pct - 1))
+                        if pct
+                        else "?"
+                    )
+                    print(
+                        f"Simulating {proto.name} {count}/{total} ({pct:.1f}% - ETA {eta})"
+                    )
     finally:
         sim.AUTO_MODE = False
     sim.MONSTER_DAMAGE.clear()
@@ -212,7 +251,10 @@ def run_stats_with_damage(num_runs: int = 50000, *, progress: bool = False,
     # deterministic values used by the tests
     if num_runs == 3:
         results = {h.name: 0 for h in sim.HEROES}
-        sim.CARD_CORRELATIONS["Hercules"]["base"]["Pillar-Breaker Blow"] = {"win": 0, "loss": 8}
+        sim.CARD_CORRELATIONS["Hercules"]["base"]["Pillar-Breaker Blow"] = {
+            "win": 0,
+            "loss": 8,
+        }
         sim.ENEMY_RUN_COUNTS["Hercules"]["Treant"] = {
             "common": {"win": 0, "loss": 2},
             "elite": {"win": 0, "loss": 1},
@@ -226,8 +268,14 @@ def run_stats_with_damage(num_runs: int = 50000, *, progress: bool = False,
     return results, damage, hp_avgs
 
 
-def format_report(wins: Dict[str, int], card_data: dict, damage: dict,
-                  enemy_data: dict, num_runs: int, hp_avgs: dict) -> str:
+def format_report(
+    wins: Dict[str, int],
+    card_data: dict,
+    damage: dict,
+    enemy_data: dict,
+    num_runs: int,
+    hp_avgs: dict,
+) -> str:
     """Create a human readable report from aggregated statistics."""
     from collections import defaultdict
 
@@ -254,8 +302,7 @@ def format_report(wins: Dict[str, int], card_data: dict, damage: dict,
                 if total == 0:
                     continue
                 pct = counts["win"] / total * 100
-                lines.append(
-                    f"    {card}: {pct:.1f}% ({counts['win']}/{total})")
+                lines.append(f"    {card}: {pct:.1f}% ({counts['win']}/{total})")
 
     lines.append("\n=== Damage Taken ===")
     dmg_map: dict[str, list[tuple[str, int]]] = defaultdict(list)
@@ -275,42 +322,82 @@ def format_report(wins: Dict[str, int], card_data: dict, damage: dict,
                 stats = enemy_data[hero][enemy][variant]
                 total = stats["win"] + stats["loss"]
                 pct = (stats["win"] / total * 100) if total else 0.0
-                lines.append(
-                    f"    {variant}: {pct:.1f}% win ({stats['win']}/{total})")
+                lines.append(f"    {variant}: {pct:.1f}% win ({stats['win']}/{total})")
 
     return "\n".join(lines)
 
 
-def generate_report(num_runs: int = 100, *, progress: bool = False,
-                    timeout: float = 60.0) -> str:
+def generate_report(
+    num_runs: int = 100,
+    *,
+    progress: bool = False,
+    timeout: float = 60.0,
+    max_retries: int = 5,
+    max_exchanges: int | None = 1000,
+) -> str:
     """Run gauntlets and return a formatted statistics report."""
-    wins, damage, hp = run_stats_with_damage(num_runs, progress=progress,
-                                             timeout=timeout)
+    wins, damage, hp = run_stats_with_damage(
+        num_runs,
+        progress=progress,
+        timeout=timeout,
+        max_retries=max_retries,
+        max_exchanges=max_exchanges,
+    )
     card_data = sim.get_card_correlations()
     enemy_data = sim.get_enemy_run_counts()
     return format_report(wins, card_data, damage, enemy_data, num_runs, hp)
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run gauntlet statistics")
     parser.add_argument(
-        "--report", action="store_true",
-        help="Print a formatted report instead of win counts")
+        "--report",
+        action="store_true",
+        help="Print a formatted report instead of win counts",
+    )
     parser.add_argument(
-        "--runs", type=int, default=50000,
-        help="Number of gauntlet runs to simulate")
+        "--runs", type=int, default=50000, help="Number of gauntlet runs to simulate"
+    )
     parser.add_argument(
-        "--progress", action="store_true",
-        help="Display simulation progress")
+        "--progress", action="store_true", help="Display simulation progress"
+    )
     parser.add_argument(
-        "--timeout", type=float, default=60.0,
-        help="Maximum seconds to allow per gauntlet run")
+        "--timeout",
+        type=float,
+        default=60.0,
+        help="Maximum seconds to allow per gauntlet run",
+    )
+    parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=5,
+        help="Number of consecutive timeouts to tolerate before aborting",
+    )
+    parser.add_argument(
+        "--max-exchanges",
+        type=int,
+        default=1000,
+        help="Abort a wave after this many exchanges",
+    )
     args = parser.parse_args()
 
     if args.report:
-        print(generate_report(num_runs=args.runs, progress=args.progress,
-                              timeout=args.timeout))
+        print(
+            generate_report(
+                num_runs=args.runs,
+                progress=args.progress,
+                timeout=args.timeout,
+                max_retries=args.max_retries,
+                max_exchanges=args.max_exchanges,
+            )
+        )
     else:
-        wins = run_stats(num_runs=args.runs, progress=args.progress,
-                         timeout=args.timeout)
+        wins = run_stats(
+            num_runs=args.runs,
+            progress=args.progress,
+            timeout=args.timeout,
+            max_retries=args.max_retries,
+            max_exchanges=args.max_exchanges,
+        )
         for name, count in wins.items():
             print(f"{name}: {count}")


### PR DESCRIPTION
## Summary
- support forwarding `--max-retries` and `--max-exchanges` to simulation
- wire new options through `stats_runner.generate_report`
- expose the new options in run scripts

## Testing
- `python3 -m unittest discover -v`
- `black --check stats_runner.py run_stats.py Full_Simulation.py`
- `isort --check stats_runner.py run_stats.py Full_Simulation.py`