### PR TITLE
Add timeout tests

### DIFF
--- a/test_sim.py
+++ b/test_sim.py
@@ -72,6 +72,17 @@ class TestMechanics(unittest.TestCase):
         self.assertIn(result, [True, False])
         self.assertLessEqual(hero.hp, hero.max_hp)
         self.assertGreaterEqual(hero.hp, 0)
+
+    def test_fight_one_max_exchanges_timeout(self):
+        """fight_one should raise when the exchange cap is reached."""
+        sim.RNG.seed(0)
+        hero = sim.Hero("Hercules", 25, sim.herc_base, sim.herc_pool)
+        with self.assertRaises(TimeoutError) as ctx:
+            sim.fight_one(hero, max_exchanges=0)
+        msg = str(ctx.exception)
+        self.assertIn("Hercules", msg)
+        self.assertIn(sim.ENEMY_WAVES[0][0], msg)
+
 class TestCorruptedDryadAbilities(unittest.TestCase):
     def test_cursed_thorns(self):
         hero = sim.Hero("Hero", 10, [])

--- a/test_stats_runner.py
+++ b/test_stats_runner.py
@@ -93,6 +93,19 @@ class TestStatsRunner(unittest.TestCase):
         self.assertIn("failed", str(ctx.exception))
         self.assertEqual(calls["n"], 3)
 
+    def test_run_gauntlet_timeout_after_max_retries(self):
+        hero = sim.Hero("Hercules", 25, sim.herc_base, sim.herc_pool)
+        calls = {"n": 0}
+
+        def always_timeout(h, hp_log=None, *, timeout=None, max_exchanges=None):
+            calls["n"] += 1
+            raise TimeoutError("boom")
+
+        with unittest.mock.patch("sim.fight_one", side_effect=always_timeout):
+            with self.assertRaises(TimeoutError):
+                stats_runner.run_gauntlet(hero, timeout=1, max_retries=1)
+        self.assertEqual(calls["n"], 2)
+
     def test_run_stats_passes_options(self):
         calls = []
 


### PR DESCRIPTION
## Summary
- test max_exchange timeout in fight_one
- test run_gauntlet fails after exceeding retries

## Testing
- `python3 -m unittest discover -v`