### PR TITLE
Default wave timeout 10s

### DIFF
--- a/Full_Simulation.py
+++ b/Full_Simulation.py
@@ -37,8 +37,8 @@ def main() -> None:
     parser.add_argument(
         "--wave-timeout",
         type=float,
-        default=None,
-        help="Abort a wave if it runs longer than this many seconds",
+        default=10.0,
+        help="Abort a wave if it runs longer than this many seconds (default: 10.0)",
     )
     parser.add_argument(
         "--max-total-exchanges",

--- a/run_stats.py
+++ b/run_stats.py
@@ -42,8 +42,8 @@ def main() -> None:
     parser.add_argument(
         "--wave-timeout",
         type=float,
-        default=None,
-        help="Abort a wave if it runs longer than this many seconds",
+        default=10.0,
+        help="Abort a wave if it runs longer than this many seconds (default: 10.0)",
     )
     parser.add_argument(
         "--max-total-exchanges",

--- a/stats_runner.py
+++ b/stats_runner.py
@@ -34,7 +34,7 @@ def run_gauntlet(
     timeout: float = 60.0,
     max_retries: int = 5,
     max_exchanges: int | None = 1000,
-    wave_timeout: float | None = None,
+    wave_timeout: float | None = 10.0,
     max_total_exchanges: int | None = None,
 ) -> bool:
     """Run one gauntlet for ``hero`` using random waves and upgrade schedule.
@@ -115,7 +115,7 @@ def run_stats(
     timeout: float = 60.0,
     max_retries: int = 5,
     max_exchanges: int | None = 1000,
-    wave_timeout: float | None = None,
+    wave_timeout: float | None = 10.0,
     max_total_exchanges: int | None = None,
 ) -> Dict[str, int]:
     """Run ``num_runs`` gauntlets for each hero and return win counts.
@@ -184,7 +184,7 @@ def run_stats_with_damage(
     timeout: float = 60.0,
     max_retries: int = 5,
     max_exchanges: int | None = 1000,
-    wave_timeout: float | None = None,
+    wave_timeout: float | None = 10.0,
     max_total_exchanges: int | None = None,
 ) -> tuple[Dict[str, int], dict, dict]:
     """Run gauntlets collecting win counts, damage and HP progression.
@@ -361,7 +361,7 @@ def generate_report(
     timeout: float = 60.0,
     max_retries: int = 5,
     max_exchanges: int | None = 1000,
-    wave_timeout: float | None = None,
+    wave_timeout: float | None = 10.0,
     max_total_exchanges: int | None = None,
 ) -> str:
     """Run gauntlets and return a formatted statistics report."""
@@ -413,8 +413,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--wave-timeout",
         type=float,
-        default=None,
-        help="Abort a wave if it runs longer than this many seconds",
+        default=10.0,
+        help="Abort a wave if it runs longer than this many seconds (default: 10.0)",
     )
     parser.add_argument(
         "--max-total-exchanges",

--- a/test_stats_runner.py
+++ b/test_stats_runner.py
@@ -88,7 +88,7 @@ class TestStatsRunner(unittest.TestCase):
             max_total_exchanges=None,
         ):
             self.assertEqual(max_exchanges, 42)
-            self.assertIsNone(wave_timeout)
+            self.assertEqual(wave_timeout, 10.0)
             self.assertIsNone(max_total_exchanges)
             return True
 


### PR DESCRIPTION
## Summary
- set default `--wave-timeout` to 10s
- document the default in CLI help
- update tests for new default value

## Testing
- `pytest -q`