### PR TITLE
Update initial spawn logic

### DIFF
--- a/dark_game_sim.py
+++ b/dark_game_sim.py
@@ -107,12 +107,11 @@ class Spot:
 
 def initial_spawn(board):
     free = [n for n in ALL if n != CENTRE]
-    picks = random.sample(free, 5)
-    for loc in picks[:2]:
-        board[loc].append(Spot('R'))
-    for loc in picks[2:4]:
-        board[loc].append(Spot('M'))
-    board[picks[4]].append(Spot('Q'))
+    picks = random.sample(free, 6)
+    types = ['M', 'M', 'R', 'R', 'Q', 'Q']
+    random.shuffle(types)
+    for loc, t in zip(picks, types):
+        board[loc].append(Spot(t))
 
 
 def spawn_spots(k):


### PR DESCRIPTION
## Summary
- sample six non-centre nodes in `initial_spawn`
- place two of each spot type (M/R/Q) randomly on sampled nodes

## Testing
- `pytest -q`