### PR TITLE
Update dark game doom timing

### DIFF
--- a/dark_game_sim.py
+++ b/dark_game_sim.py
@@ -206,6 +206,9 @@ def spawn_end_of_round(rnd, verbose=False):
         if verbose:
             print(f"    Rift spawn at {loc}")
 
+    rift_locs = [
+        loc for loc, spots in board.items() if any(s.t == 'R' for s in spots)
+    ]
     for loc in rift_locs:
         if random.random() < 0.75:
             board[loc].append(Spot('M'))
@@ -363,12 +366,12 @@ def play_game(verbose=False, return_loss_detail=False):
                 spawn_new_quest(verbose)
 
         if rnd < TOTAL_ROUNDS:
+            cnts = Counter(s.t for p in board.values() for s in p)
+            doom += cnts['M']
             if verbose:
                 print(" End-of-round Darkness:")
             end_of_round_darkness(rnd, verbose)
             spawn_end_of_round(rnd, verbose)
-            cnts = Counter(s.t for p in board.values() for s in p)
-            doom += cnts['M']
             if sum(dark_map[c] for c in dark_map if c != 'A') == 8:
                 full_loss = True
                 if verbose:

--- a/test_dark_end_round.py
+++ b/test_dark_end_round.py
@@ -1,0 +1,32 @@
+import unittest
+import random
+from collections import defaultdict
+from unittest.mock import patch
+import dark_game_sim as dgs
+
+class TestEndOfRoundSpawning(unittest.TestCase):
+    def test_monsters_spawn_from_all_rifts(self):
+        dgs.board = defaultdict(list)
+        dgs.board[5].append(dgs.Spot('R'))
+        with patch('dark_game_sim.random.sample', return_value=[6]), \
+             patch('dark_game_sim.random.random', side_effect=[0.0, 0.0, 0.0]):
+            dgs.spawn_end_of_round(1)
+        rift_locs = [loc for loc, spots in dgs.board.items() if any(s.t == 'R' for s in spots)]
+        mons_at = [loc for loc, spots in dgs.board.items() if any(s.t == 'M' for s in spots)]
+        self.assertCountEqual(rift_locs, [5, 6])
+        self.assertTrue(all(loc in mons_at for loc in [5, 6]))
+
+class TestPlayGameDoom(unittest.TestCase):
+    def test_doom_before_spawning(self):
+        random.seed(0)
+        def fake_spawn_end_of_round(rnd, verbose=False):
+            dgs.board[1].append(dgs.Spot('M'))
+        with patch.object(dgs, 'HERO_SPEED', 0), \
+             patch.object(dgs, 'TOTAL_ROUNDS', 3), \
+             patch('dark_game_sim.spawn_end_of_round', side_effect=fake_spawn_end_of_round):
+            res = dgs.play_game(return_loss_detail=True)
+        self.assertEqual(res['end_mons'], 4)
+        self.assertEqual(res['end_doom'], 5)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- spawn monsters from *all* rifts each end of round
- count doom before spawning at the end of each round
- test rift spawning behaviour and doom ordering

## Testing
- `pytest -q`