### PR TITLE
Modify monster spawning logic

### DIFF
--- a/dark_game_sim.py
+++ b/dark_game_sim.py
@@ -107,7 +107,7 @@ class Spot:
 def initial_spawn(board):
     free = [n for n in ALL if n != CENTRE]
     picks = random.sample(free, 6)
-    types = ['M', 'M', 'R', 'R', 'Q', 'Q']
+    types = ['R', 'R', 'Q', 'Q', 'Q', 'Q']
     random.shuffle(types)
     for loc, t in zip(picks, types):
         board[loc].append(Spot(t))
@@ -193,9 +193,15 @@ def spawn_end_of_round(rnd, verbose=False):
     if rnd <= 3:
         k = 1 if random.random() < 0.75 else 0
     elif rnd <= 6:
-        k = 1 + (random.random() < 0.5)
+        r = random.random()
+        if r < 0.25:
+            k = 2
+        elif r < 0.75:
+            k = 1
+        else:
+            k = 0
     elif rnd <= 8:
-        k = 2 + (random.random() < 0.5)
+        k = 1 + (random.random() < 0.5)
     else:
         k = 0
 
@@ -210,10 +216,11 @@ def spawn_end_of_round(rnd, verbose=False):
         loc for loc, spots in board.items() if any(s.t == 'R' for s in spots)
     ]
     for loc in rift_locs:
-        if random.random() < 0.75:
-            board[loc].append(Spot('M'))
-            if verbose:
-                print(f"    Monster spawn at {loc}")
+        cl = NODE_TO_CLUSTER[loc]
+        spawn_loc = random.choice(CLUSTERS[cl])
+        board[spawn_loc].append(Spot('M'))
+        if verbose:
+            print(f"    Monster spawn at {spawn_loc}")
 
 # ───────── Priority helpers ─────────
 def compute_priority(dark_cnt, rift_cnt, mons_cnt):

--- a/test_dark_end_round.py
+++ b/test_dark_end_round.py
@@ -9,12 +9,12 @@ class TestEndOfRoundSpawning(unittest.TestCase):
         dgs.board = defaultdict(list)
         dgs.board[5].append(dgs.Spot('R'))
         with patch('dark_game_sim.random.sample', return_value=[6]), \
-             patch('dark_game_sim.random.random', side_effect=[0.0, 0.0, 0.0]):
+             patch('dark_game_sim.random.choice', side_effect=[4, 7]):
             dgs.spawn_end_of_round(1)
         rift_locs = [loc for loc, spots in dgs.board.items() if any(s.t == 'R' for s in spots)]
         mons_at = [loc for loc, spots in dgs.board.items() if any(s.t == 'M' for s in spots)]
         self.assertCountEqual(rift_locs, [5, 6])
-        self.assertTrue(all(loc in mons_at for loc in [5, 6]))
+        self.assertCountEqual(mons_at, [4, 7])
 
 class TestPlayGameDoom(unittest.TestCase):
     def test_doom_before_spawning(self):
@@ -25,8 +25,8 @@ class TestPlayGameDoom(unittest.TestCase):
              patch.object(dgs, 'TOTAL_ROUNDS', 3), \
              patch('dark_game_sim.spawn_end_of_round', side_effect=fake_spawn_end_of_round):
             res = dgs.play_game(return_loss_detail=True)
-        self.assertEqual(res['end_mons'], 4)
-        self.assertEqual(res['end_doom'], 5)
+        self.assertEqual(res['end_mons'], 2)
+        self.assertEqual(res['end_doom'], 1)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- remove monsters from `initial_spawn`
- spawn a monster for every rift each round and place it on a random node in the rift's cluster
- update tests for new spawn behaviour

## Testing
- `pytest -q`