### PR TITLE
Add tunable spawn probabilities

### DIFF
--- a/dark_game_sim.py
+++ b/dark_game_sim.py
@@ -8,6 +8,25 @@ from itertools import permutations
 HERO_SPEED   = 2
 TOTAL_ROUNDS = 9
 RUNS         = 2500
+
+# --- Spawn configuration ---
+# Chance that a monster spawns from each rift every round
+MONSTER_SPAWN_CHANCE = 1.0
+
+# Chance of new rifts appearing each round.  The dictionary maps the
+# round number to a list of ``(probability, count)`` tuples.  The
+# probability values are cumulative thresholds evaluated against
+# ``random.random()``.  Edit these values to tweak rift behaviour.
+RIFT_SPAWN_RULES = {
+    1: [(0.75, 1)],
+    2: [(0.75, 1)],
+    3: [(0.75, 1)],
+    4: [(0.25, 2), (0.75, 1)],
+    5: [(0.25, 2), (0.75, 1)],
+    6: [(0.25, 2), (0.75, 1)],
+    7: [(0.5, 2), (1.0, 1)],
+    8: [(0.5, 2), (1.0, 1)],
+}
 # ──────────────────────────────────────────────
 
 # ---------------- Graph ----------------
@@ -185,25 +204,24 @@ def end_of_round_darkness(rnd, verbose=False):
                     print(f"    Filled dark at {CLUSTER_MAJOR[cl]} ({cl})")
 
 
+def rift_spawn_count(rnd):
+    """Return the number of new rifts to spawn for the given round."""
+    rules = RIFT_SPAWN_RULES.get(rnd)
+    if not rules:
+        return 0
+    r = random.random()
+    for prob, count in rules:
+        if r < prob:
+            return count
+    return 0
+
+
 def spawn_end_of_round(rnd, verbose=False):
     global board
     if rnd == 9:
         return
 
-    if rnd <= 3:
-        k = 1 if random.random() < 0.75 else 0
-    elif rnd <= 6:
-        r = random.random()
-        if r < 0.25:
-            k = 2
-        elif r < 0.75:
-            k = 1
-        else:
-            k = 0
-    elif rnd <= 8:
-        k = 1 + (random.random() < 0.5)
-    else:
-        k = 0
+    k = rift_spawn_count(rnd)
 
     free = [n for n in ALL if n != CENTRE and not board.get(n)]
     rift_locs = random.sample(free, min(k, len(free)))
@@ -216,11 +234,12 @@ def spawn_end_of_round(rnd, verbose=False):
         loc for loc, spots in board.items() if any(s.t == 'R' for s in spots)
     ]
     for loc in rift_locs:
-        cl = NODE_TO_CLUSTER[loc]
-        ml = random.choice(CLUSTERS[cl])
-        board[ml].append(Spot('M'))
-        if verbose:
-            print(f"    Monster spawn at {ml}")
+        if random.random() < MONSTER_SPAWN_CHANCE:
+            cl = NODE_TO_CLUSTER[loc]
+            ml = random.choice(CLUSTERS[cl])
+            board[ml].append(Spot('M'))
+            if verbose:
+                print(f"    Monster spawn at {ml}")
 
 # ───────── Priority helpers ─────────
 def compute_priority(dark_cnt, rift_cnt, mons_cnt):


### PR DESCRIPTION
## Summary
- add configuration for monster and rift spawn probabilities in `dark_game_sim.py`
- add helper `rift_spawn_count` used by `spawn_end_of_round`
- spawn monsters from rifts only when chance passes

## Testing
- `pytest -q`