### PR TITLE
Implement hero HP threshold reporting

### DIFF
--- a/experiment.py
+++ b/experiment.py
@@ -73,7 +73,7 @@ def run_experiments(
         if card_fn:
             card_fn(True)
 
-        wins, _damage, hp_avgs = stats_runner.run_stats_with_damage(
+        wins, _damage, hp_avgs, _hp_thresh = stats_runner.run_stats_with_damage(
             num_runs=num_runs,
             progress=progress,
             timeout=timeout,

--- a/test_reporting.py
+++ b/test_reporting.py
@@ -10,8 +10,19 @@ class TestReporting(unittest.TestCase):
         for hero in [h.name for h in sim.HEROES]:
             self.assertIn(hero, report)
         self.assertIn("Hero Win Rates", report)
+        self.assertIn("30% HP", report)
+        self.assertIn("Armor stacking", report)
         self.assertIn("Enemy Appearance Outcomes", report)
         self.assertIn("base:", report)
+
+    def test_format_report_marks_outliers(self):
+        wins = {"A": 30, "B": 70}
+        hp = {"A": [0] * 8, "B": [0] * 8}
+        over = {"A": 0, "B": 30}
+        report = stats_runner.format_report(wins, {}, {}, {}, 100, hp, over)
+        b_line = next(l for l in report.splitlines() if l.startswith("B:"))
+        self.assertTrue(b_line.endswith("*"))
+        self.assertIn("Armor stacking", report)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_run_counters.py
+++ b/test_run_counters.py
@@ -5,7 +5,7 @@ import stats_runner
 class TestSimulationCounters(unittest.TestCase):
     def test_run_stats_aggregates(self):
         sim.RNG.seed(0)
-        wins, damage, hp = stats_runner.run_stats_with_damage(num_runs=3)
+        wins, damage, hp, over = stats_runner.run_stats_with_damage(num_runs=3)
         # win counters should record a loss for each hero
         expected_wins = {h.name: 0 for h in sim.HEROES}
         self.assertEqual(wins, expected_wins)

--- a/test_stats_runner.py
+++ b/test_stats_runner.py
@@ -14,9 +14,10 @@ class TestStatsRunner(unittest.TestCase):
 
     def test_run_stats_with_hp(self):
         sim.RNG.seed(1)
-        wins, damage, hp = stats_runner.run_stats_with_damage(num_runs=1)
+        wins, damage, hp, over = stats_runner.run_stats_with_damage(num_runs=1)
         hero_names = {h.name for h in sim.HEROES}
         self.assertEqual(set(hp.keys()), hero_names)
+        self.assertEqual(set(over.keys()), hero_names)
         for vals in hp.values():
             self.assertEqual(len(vals), 8)
             for v in vals:
@@ -25,7 +26,7 @@ class TestStatsRunner(unittest.TestCase):
     def test_hp_log_fills_zeros_after_death(self):
         """HP logs should contain zeros after an early death."""
         sim.RNG.seed(0)
-        _, _, hp = stats_runner.run_stats_with_damage(num_runs=1)
+        _, _, hp, _ = stats_runner.run_stats_with_damage(num_runs=1)
         vals = hp.get("Hercules")
         self.assertIsNotNone(vals)
         self.assertEqual(len(vals), 8)


### PR DESCRIPTION
## Summary
- collect how often heroes finish above 30% HP
- flag heroes with unusual win rates or HP stats
- report if armor stacking leads to high-HP finishes
- adapt experiment utilities and tests to new data

## Testing
- `pytest -q`