### PR TITLE
Add min_damage configuration

### DIFF
--- a/run_stats.py
+++ b/run_stats.py
@@ -51,6 +51,11 @@ def main() -> None:
         default=None,
         help="Abort the gauntlet after this many total exchanges",
     )
+    parser.add_argument(
+        "--min-damage",
+        action="store_true",
+        help="Monsters always deal at least 1 damage after armor",
+    )
     args = parser.parse_args()
 
     report = stats_runner.generate_report(
@@ -61,6 +66,7 @@ def main() -> None:
         max_exchanges=args.max_exchanges,
         wave_timeout=args.wave_timeout,
         max_total_exchanges=args.max_total_exchanges,
+        min_damage=args.min_damage,
     )
     print(report)
 

--- a/sim.py
+++ b/sim.py
@@ -19,6 +19,10 @@ RNG = random.Random()
 # gameplay because all interactive prompts have been removed.
 AUTO_MODE = False
 
+# When ``MIN_DAMAGE`` is ``True`` monsters always inflict at least 1 HP
+# of damage after armor so long as the attack dealt positive damage.
+MIN_DAMAGE = False
+
 # Each enemy template stores its own damage band so the old per-wave
 # ``BANDS`` table is no longer required.  Enemy lookups below provide the
 # appropriate values for each wave.
@@ -547,7 +551,10 @@ def cleave_all(hero_list: List[Hero], dmg: int) -> None:
     for h in hero_list:
         soak = min(h.armor_pool, dmg)
         h.armor_pool -= soak
-        h.hp -= max(0, dmg - soak)
+        taken = max(0, dmg - soak)
+        if MIN_DAMAGE and dmg > 0 and taken == 0:
+            taken = 1
+        h.hp -= taken
 
 def enrage(enemy: Enemy) -> bool:
     """Return True if ``enemy`` is enraged and attacks twice."""
@@ -2575,6 +2582,8 @@ def monster_attack(heroes: List[Hero], ctx: Dict[str, object]) -> None:
         soak = min(hero.armor_pool, dmg)
         hero.armor_pool -= soak
         taken = max(0, dmg - soak)
+        if MIN_DAMAGE and dmg > 0 and taken == 0:
+            taken = 1
         hero.hp -= taken
         if enemy:
             MONSTER_DAMAGE[(hero.name, enemy.name)] += taken

--- a/test_sim.py
+++ b/test_sim.py
@@ -291,6 +291,21 @@ class TestMinotaurAbilities(unittest.TestCase):
         sim.monster_attack([hero], ctx)
         self.assertEqual(hero.hp, 2)
 
+    def test_min_damage_rule(self):
+        hero = sim.Hero("Hero", 10, [])
+        hero.armor_pool = 5
+        enemy = sim.Enemy("Goblin", 1, 1, sim.Element.NONE, [1, 1, 1, 1])
+        ctx = {"enemies": [enemy]}
+        sim.MIN_DAMAGE = False
+        sim.monster_attack([hero], ctx)
+        self.assertEqual(hero.hp, 10)
+        hero.hp = 10
+        hero.armor_pool = 5
+        sim.MIN_DAMAGE = True
+        sim.monster_attack([hero], ctx)
+        self.assertEqual(hero.hp, 9)
+        sim.MIN_DAMAGE = False
+
 
 class TestMonsterDamageTracking(unittest.TestCase):
     def test_damage_logged(self):

--- a/test_stats_runner.py
+++ b/test_stats_runner.py
@@ -232,9 +232,10 @@ class TestStatsRunner(unittest.TestCase):
             max_exchanges=None,
             wave_timeout=None,
             max_total_exchanges=None,
+            min_damage=None,
         ):
             calls.append(
-                (timeout, max_retries, max_exchanges, wave_timeout, max_total_exchanges)
+                (timeout, max_retries, max_exchanges, wave_timeout, max_total_exchanges, min_damage)
             )
             return True
 
@@ -250,12 +251,13 @@ class TestStatsRunner(unittest.TestCase):
             )
 
         self.assertEqual(len(calls), len(sim.HEROES))
-        for t, r, e, w, m in calls:
+        for t, r, e, w, m, d in calls:
             self.assertEqual(t, 1.5)
             self.assertEqual(r, 7)
             self.assertEqual(e, 44)
             self.assertEqual(w, 0.5)
             self.assertEqual(m, 123)
+            self.assertFalse(d)
 
     def test_run_stats_with_damage_passes_options(self):
         calls = []
@@ -269,9 +271,10 @@ class TestStatsRunner(unittest.TestCase):
             max_exchanges=None,
             wave_timeout=None,
             max_total_exchanges=None,
+            min_damage=None,
         ):
             calls.append(
-                (timeout, max_retries, max_exchanges, wave_timeout, max_total_exchanges)
+                (timeout, max_retries, max_exchanges, wave_timeout, max_total_exchanges, min_damage)
             )
             return True
 
@@ -287,12 +290,13 @@ class TestStatsRunner(unittest.TestCase):
             )
 
         self.assertEqual(len(calls), len(sim.HEROES))
-        for t, r, e, w, m in calls:
+        for t, r, e, w, m, d in calls:
             self.assertEqual(t, 2.5)
             self.assertEqual(r, 8)
             self.assertEqual(e, 55)
             self.assertEqual(w, 1.5)
             self.assertEqual(m, 321)
+            self.assertFalse(d)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- introduce `MIN_DAMAGE` flag in `sim`
- enforce minimum damage in `cleave_all` and monster attacks
- pass `min_damage` option through stats functions and CLI
- allow experiment runner to sweep `min_damage` values
- update tests for new option and add coverage

## Testing
- `pytest -q`