### PR TITLE
Add experiment summary test and deterministic report

### DIFF
--- a/stats_runner.py
+++ b/stats_runner.py
@@ -330,7 +330,9 @@ def format_report(
     lines: list[str] = []
 
     lines.append("=== Hero Win Rates ===")
-    for hero in sorted(wins):
+    # iterate heroes in a deterministic order even if dictionaries are sparse
+    hero_names = sorted(set(wins) | set(hp_avgs) | set(hp_thresh))
+    for hero in hero_names:
         rate = (wins[hero] / num_runs) * 100 if num_runs else 0.0
         over = (hp_thresh.get(hero, 0) / num_runs) * 100 if num_runs else 0.0
         flag = "" if 40 <= rate <= 60 and over <= 20 else " *"
@@ -340,8 +342,8 @@ def format_report(
         lines.append(f"  HP after fights: {hp_str}")
         lines.append(f"  >30% HP: {over:.1f}% ({hp_thresh.get(hero,0)}/{num_runs})")
 
-    total_over = sum(hp_thresh.values())
-    total_runs = num_runs * len(hp_thresh)
+    total_over = sum(hp_thresh.get(h, 0) for h in hero_names)
+    total_runs = num_runs * len(hero_names)
     overall = (total_over / total_runs) * 100 if total_runs else 0.0
     stacking = "yes" if overall > 20 else "no"
     lines.append(f"Armor stacking >30% HP runs >20%: {stacking} ({overall:.1f}% overall)")

--- a/test_experiment.py
+++ b/test_experiment.py
@@ -3,6 +3,8 @@ import unittest.mock
 import experiment
 import stats_runner
 import sim
+import io
+import contextlib
 
 
 class TestExperimentRunner(unittest.TestCase):
@@ -179,6 +181,79 @@ class TestExperimentRunner(unittest.TestCase):
         self.assertFalse(sim.TOTAL_MIN_DAMAGE)
 
         self.assertNotEqual(results_total[0]["wins"], results_per[0]["wins"])
+
+    def test_summary_report_for_multiple_rules(self):
+        """Run several armor rules and verify the formatted summary output."""
+
+        def rule_balanced(apply: bool) -> None:
+            pass
+
+        def rule_overpowered(apply: bool) -> None:
+            pass
+
+        def rule_underpowered(apply: bool) -> None:
+            pass
+
+        # predetermined win/high HP outcomes for the three rules above
+        outcomes = [
+            (1, 0),  # balanced: 50% win rate, 0% high-HP
+            (2, 1),  # overpowered: 100% win rate, 50% high-HP
+            (0, 0),  # underpowered: 0% win rate, 0% high-HP
+        ]
+
+        def fake_run_stats_with_damage(*args, **kwargs):
+            idx = fake_run_stats_with_damage.calls
+            fake_run_stats_with_damage.calls += 1
+            wins_per_hero, over_count = outcomes[idx]
+            return (
+                {h.name: wins_per_hero for h in sim.HEROES},
+                {},
+                {h.name: [0] * 8 for h in sim.HEROES},
+                {h.name: over_count for h in sim.HEROES},
+            )
+
+        fake_run_stats_with_damage.calls = 0
+
+        with unittest.mock.patch(
+            "stats_runner.run_stats_with_damage", side_effect=fake_run_stats_with_damage
+        ):
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                results = experiment.run_experiments(
+                    hp_values=[20],
+                    damage_multipliers=[1.0],
+                    armor_rules=[rule_balanced, rule_overpowered, rule_underpowered],
+                    num_runs=2,
+                )
+                for entry in results:
+                    print(entry["armor_rule"])
+                    report = stats_runner.format_report(
+                        entry["wins"],
+                        {},
+                        {},
+                        {},
+                        2,
+                        entry["hp_avgs"],
+                        entry["hp_thresh"],
+                    )
+                    print(report)
+            summary = buf.getvalue()
+
+        # Balanced rule should not be flagged
+        self.assertIn("rule_balanced", summary)
+        self.assertIn("Hercules: 50.0% (1/2)", summary)
+        self.assertIn(">30% HP: 0.0% (0/2)", summary)
+        self.assertNotIn("50.0% (1/2) *", summary)
+
+        # Overpowered rule should be flagged for high win rate and HP
+        self.assertIn("rule_overpowered", summary)
+        self.assertIn("Hercules: 100.0% (2/2) *", summary)
+        self.assertIn(">30% HP: 50.0% (1/2)", summary)
+
+        # Underpowered rule should be flagged for low win rate
+        self.assertIn("rule_underpowered", summary)
+        self.assertIn("Hercules: 0.0% (0/2) *", summary)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure `stats_runner.format_report` iterates heroes deterministically
- add a comprehensive test running multiple armor rules and validating
  formatted summary output

## Testing
- `pytest -q`