### PR TITLE
Document deterministic results path

### DIFF
--- a/stats_runner.py
+++ b/stats_runner.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Mass gauntlet simulator."""
+"""Mass gauntlet simulator.
+
+This module exposes :func:`run_stats_with_damage`, which provides
+deterministic values when ``num_runs == 3``. The hardcoded results are used
+by the test suite to assert aggregation logic without relying on random
+simulation outcomes.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- add explanation of deterministic results to stats_runner module docstring

## Testing
- `pytest -q`