### PR TITLE
Add monster action tables and ability effects

### DIFF
--- a/simulator.py
+++ b/simulator.py
@@ -86,15 +86,41 @@ class Monster:
     defense: int
     type: str
     abilities: List[str] = field(default_factory=list)
+    action_table: List[Dict[str, int]] = field(default_factory=lambda: [
+        {"damage": 1, "armor": 0},
+        {"damage": 1, "armor": 1},
+        {"damage": 2, "armor": 0},
+        {"damage": 3, "armor": 1},
+    ])
     armor: int = 0
 
     def roll_action(self) -> (int, int):
-        """Return (damage, armor) for the exchange."""
-        damage = random.randint(1, self.defense)
-        armor = 0
+        """Return (damage, armor) for the exchange using a d8 table."""
+        roll = random.randint(1, 8)
+        idx = (roll - 1) // 2
+        entry = self.action_table[min(idx, len(self.action_table) - 1)]
+        damage = entry.get("damage", 0)
+        armor = entry.get("armor", 0)
         if "tough" in self.abilities:
             armor += 1
         return damage, armor
+
+
+# Generic action tables used for monsters. Each entry corresponds to
+# results for d8 rolls of 1-2, 3-4, 5-6 and 7-8 respectively.
+BASIC_ACTION_TABLE = [
+    {"damage": 1, "armor": 0},
+    {"damage": 1, "armor": 1},
+    {"damage": 2, "armor": 0},
+    {"damage": 3, "armor": 1},
+]
+
+ELITE_ACTION_TABLE = [
+    {"damage": 1, "armor": 1},
+    {"damage": 2, "armor": 1},
+    {"damage": 3, "armor": 1},
+    {"damage": 4, "armor": 2},
+]
 
 
 @dataclass
@@ -108,48 +134,68 @@ class EnemyGroup:
 # Enemy groups from the design reference
 BASIC_GROUPS: List[EnemyGroup] = [
     EnemyGroup(3, Monster("Shadow Spinner", hp=1, defense=4, type="spiritual",
-                          abilities=["Web Slinger: Ranged attacks are considered Melee."])),
+                          abilities=["Web Slinger"],
+                          action_table=BASIC_ACTION_TABLE)),
     EnemyGroup(3, Monster("Void Soldier", hp=2, defense=5, type="precise",
-                          abilities=["Dark Phalanx: Soldiers take -1 <DMG> (min. 1) from multi target attacks, if at least 2 Soldiers are alive."])),
+                          abilities=["Dark Phalanx"],
+                          action_table=BASIC_ACTION_TABLE)),
     EnemyGroup(3, Monster("Priest of Oblivion", hp=2, defense=3, type="arcane",
-                          abilities=["Power of Death: Priests deal +1 <DMG> for each dead Priest in this combat."])),
+                          abilities=["Power of Death"],
+                          action_table=BASIC_ACTION_TABLE)),
     EnemyGroup(3, Monster("Corrupted Dryad", hp=2, defense=4, type="brutal",
-                          abilities=["Cursed Thorns: Unused <ARMOR> at end of Exchange cause hero to lose that amount of <HP>."])),
+                          abilities=["Cursed Thorns"],
+                          action_table=BASIC_ACTION_TABLE)),
     EnemyGroup(2, Monster("Dark Minotaur", hp=4, defense=3, type="precise",
-                          abilities=["Cleaving and Stomping: Minotaurs deals <DMG> to each hero in battle."])),
+                          abilities=["Cleaving and Stomping"],
+                          action_table=BASIC_ACTION_TABLE)),
     EnemyGroup(2, Monster("Dark Wizard", hp=2, defense=3, type="brutal",
-                          abilities=["Curse of Torment: Hero takes 1 <DMG> whenever it rolls a 1 or 2 (after rerolls)."])),
+                          abilities=["Curse of Torment"],
+                          action_table=BASIC_ACTION_TABLE)),
     EnemyGroup(2, Monster("Shadow Banshee", hp=3, defense=5, type="divine",
-                          abilities=["Ghostly: Start of 4th Exchange, end combat without resolution. MOVE Banshees to the next letter Location in this tile."])),
+                          abilities=["Ghostly"],
+                          action_table=BASIC_ACTION_TABLE)),
     EnemyGroup(1, Monster("Void Gryphon", hp=4, defense=5, type="spiritual",
-                          abilities=["Aerial Combat: Melee Attacks have -1 to <Hit> the Gryphon."])),
+                          abilities=["Aerial Combat"],
+                          action_table=BASIC_ACTION_TABLE)),
     EnemyGroup(1, Monster("Void Treant", hp=7, defense=6, type="divine",
-                          abilities=["Power Sap: End of each Exchange, end 1 Combat effect. If it does, HEAL 1 the Treant."])),
+                          abilities=["Power Sap"],
+                          action_table=BASIC_ACTION_TABLE)),
     EnemyGroup(1, Monster("Corrupted Angel", hp=5, defense=5, type="arcane",
-                          abilities=["Corrupted Destiny: Start of each Exchange, the hero loses 2 <Fate>."])),
+                          abilities=["Corrupted Destiny"],
+                          action_table=BASIC_ACTION_TABLE)),
 ]
 
 ELITE_GROUPS: List[EnemyGroup] = [
     EnemyGroup(3, Monster("Shadow Spinner", hp=2, defense=5, type="spiritual",
-                          abilities=["Sticky Web: Heroes DRAW -1 card on each Exchange draws."])),
+                          abilities=["Sticky Web"],
+                          action_table=ELITE_ACTION_TABLE)),
     EnemyGroup(3, Monster("Void Soldier", hp=3, defense=6, type="precise",
-                          abilities=["Spiked Armor: Whenever a single attack deals 3+ <DMG> against a Soldier, the hero loses 1 <HP>."])),
+                          abilities=["Spiked Armor"],
+                          action_table=ELITE_ACTION_TABLE)),
     EnemyGroup(3, Monster("Priest of Oblivion", hp=3, defense=4, type="arcane",
-                          abilities=["Silence: No Combat or Exchange cards apply their effects."])),
+                          abilities=["Silence"],
+                          action_table=ELITE_ACTION_TABLE)),
     EnemyGroup(3, Monster("Corrupted Dryad", hp=2, defense=5, type="brutal",
-                          abilities=["Disturbed Flow: Dice can't be rerolled in this combat."])),
+                          abilities=["Disturbed Flow"],
+                          action_table=ELITE_ACTION_TABLE)),
     EnemyGroup(2, Monster("Dark Minotaur", hp=5, defense=3, type="precise",
-                          abilities=["Enrage: When at 3 <HP> or less, the Minotaur attacks twice."])),
+                          abilities=["Enrage"],
+                          action_table=ELITE_ACTION_TABLE)),
     EnemyGroup(2, Monster("Dark Wizard", hp=2, defense=4, type="brutal",
-                          abilities=["Void Barrier: Gain 1 <Armor> for each different type of Element <DMG> applied against it. (<B>, <P>, etc...)"])),
+                          abilities=["Void Barrier"],
+                          action_table=ELITE_ACTION_TABLE)),
     EnemyGroup(2, Monster("Shadow Banshee", hp=4, defense=5, type="divine",
-                          abilities=["Banshee Wail: Deal 1 <DMG> to all heroes in this Combat for each 3 dice rolled against this Banshee in the Exchange (rounded down)."])),
+                          abilities=["Banshee Wail"],
+                          action_table=ELITE_ACTION_TABLE)),
     EnemyGroup(1, Monster("Void Gryphon", hp=5, defense=5, type="spiritual",
-                          abilities=["Ephemeral Wings: After you deal <DMG> to the Gryphon, your next card in the Exchange deals no <DMG> to it."])),
+                          abilities=["Ephemeral Wings"],
+                          action_table=ELITE_ACTION_TABLE)),
     EnemyGroup(1, Monster("Void Treant", hp=8, defense=7, type="divine",
-                          abilities=["Roots of Despair: Whenever a hero miss all dice on an attack card, it loses 1 <HP>."])),
+                          abilities=["Roots of Despair"],
+                          action_table=ELITE_ACTION_TABLE)),
     EnemyGroup(1, Monster("Corrupted Angel", hp=7, defense=6, type="arcane",
-                          abilities=["Denied Heaven: Reroll all dice whose face is 8 (as many times as necessary)."])),
+                          abilities=["Denied Heaven"],
+                          action_table=ELITE_ACTION_TABLE)),
 ]
 
 
@@ -164,16 +210,28 @@ class Combat:
     def exchange(self) -> bool:
         """Run a single exchange. Return True if both combatants live."""
         draw_seq = [3, 2, 1, 0]
+        draw_amt = draw_seq[self.round] if self.round < len(draw_seq) else 0
+        if "Sticky Web" in self.monster.abilities:
+            draw_amt = max(0, draw_amt - 1)
+        if "Corrupted Destiny" in self.monster.abilities:
+            self.hero.fate = max(0, self.hero.fate - 2)
+        if "Ghostly" in self.monster.abilities and self.round >= 3:
+            return False
         if self.round < len(draw_seq):
-            self.hero.draw(draw_seq[self.round])
+            self.hero.draw(draw_amt)
         self.round += 1
+
+        is_web = "Web Slinger" in self.monster.abilities
 
         ranged = [c for c in self.hero.hand if c.type == "ranged"]
         melee = [c for c in self.hero.hand if c.type == "melee"]
         self.hero.hand.clear()
-        order = ranged + melee
+        order = melee + ranged if is_web else ranged + melee
 
         cancel_next = "cancel" in self.monster.abilities
+
+        dice_count = 0
+        skip_next = False
 
         for card in order:
             if cancel_next:
@@ -187,30 +245,70 @@ class Combat:
 
             dmg = 0
             count, sides = parse_dice(card.dice)
+            dice_count += count
             rerolls = 0
+            hits = 0
+            target_def = self.monster.defense
+            card_type = card.type
+            if is_web and card.type == "ranged":
+                card_type = "melee"
+            if "Aerial Combat" in self.monster.abilities and card_type == "melee":
+                target_def += 1
             for _ in range(count):
                 result = random.randint(1, sides)
-                while (result < self.monster.defense and self.hero.fate > 0
-                       and rerolls < 2 and self.monster.hp <= 2):
+                while "Denied Heaven" in self.monster.abilities and result == 8:
+                    result = random.randint(1, sides)
+                while (result < target_def and self.hero.fate > 0 and
+                       rerolls < 2 and self.monster.hp <= 2 and
+                       "Disturbed Flow" not in self.monster.abilities):
                     self.hero.fate -= 1
                     rerolls += 1
                     result = random.randint(1, sides)
-                if result >= self.monster.defense:
+                    while "Denied Heaven" in self.monster.abilities and result == 8:
+                        result = random.randint(1, sides)
+                if result in (1, 2) and "Curse of Torment" in self.monster.abilities:
+                    self.hero.apply_damage(1)
+                if result >= target_def:
                     hit = 2 if random.random() < 0.2 else 1
                     dmg += hit
-            dmg += card.effects.get("damage", 0)
-            arm = card.effects.get("armor", 0)
+                    hits += 1
+            if hits == 0 and "Roots of Despair" in self.monster.abilities:
+                self.hero.apply_damage(1)
+
+            if "Silence" not in self.monster.abilities:
+                dmg += card.effects.get("damage", 0)
+                arm = card.effects.get("armor", 0)
+            else:
+                arm = 0
             self.hero.add_armor(arm)
+
+            if skip_next:
+                dmg = 0
+                skip_next = False
+
             actual = max(0, dmg - self.monster.armor)
             self.monster.armor = max(0, self.monster.armor - dmg)
             self.monster.hp -= actual
 
-            if "shot" in self.monster.abilities and card.type == "ranged" and self.monster.hp > 0:
+            if "Spiked Armor" in self.monster.abilities and actual >= 3:
                 self.hero.apply_damage(1)
+
+            if "shot" in self.monster.abilities and card_type == "ranged" and self.monster.hp > 0:
+                self.hero.apply_damage(1)
+
+            if "Ephemeral Wings" in self.monster.abilities and actual > 0:
+                skip_next = True
 
             self.hero.discard.append(card)
 
+        if "Banshee Wail" in self.monster.abilities:
+            self.hero.apply_damage(dice_count // 3)
+
         dmg, arm = self.monster.roll_action()
+        if "Enrage" in self.monster.abilities and self.monster.hp <= 3:
+            extra_dmg, extra_arm = self.monster.roll_action()
+            dmg += extra_dmg
+            arm += extra_arm
         self.monster.armor += arm
         if self.monster.hp > 0:
             if "pierce" in self.monster.abilities:
@@ -223,8 +321,11 @@ class Combat:
             if "poison" in self.monster.abilities:
                 self.hero.apply_damage(1)
 
+        leftover = self.hero.armor
         self.hero.reset_armor()
         self.monster.armor = 0
+        if "Cursed Thorns" in self.monster.abilities and leftover > 0:
+            self.hero.apply_damage(leftover)
         return self.hero.hp > 0 and self.monster.hp > 0
 
     def run(self) -> None:
@@ -403,8 +504,14 @@ def run_trials(hero_name: str, n: int) -> None:
         encounters: List[Monster] = []
         for g in groups:
             # single representative monster per group
-            encounters.append(Monster(g.monster.name, g.monster.hp, g.monster.defense,
-                                      g.monster.type, g.monster.abilities.copy()))
+            encounters.append(Monster(
+                g.monster.name,
+                g.monster.hp,
+                g.monster.defense,
+                g.monster.type,
+                g.monster.abilities.copy(),
+                g.monster.action_table[:],
+            ))
         return encounters
 
     def run_combat(h: Hero, m: Monster) -> Dict[str, int]:
@@ -414,16 +521,28 @@ def run_trials(hero_name: str, n: int) -> None:
         hero_hp: List[int] = []
         while h.hp > 0 and m.hp > 0:
             draw_seq = [3, 2, 1, 0]
+            draw_amt = draw_seq[round_num] if round_num < len(draw_seq) else 0
+            if "Sticky Web" in m.abilities:
+                draw_amt = max(0, draw_amt - 1)
             if round_num < len(draw_seq):
-                h.draw(draw_seq[round_num])
+                h.draw(draw_amt)
+            if "Corrupted Destiny" in m.abilities:
+                h.fate = max(0, h.fate - 2)
+            if "Ghostly" in m.abilities and round_num >= 3:
+                break
             round_num += 1
+
+            is_web = "Web Slinger" in m.abilities
 
             ranged = [c for c in h.hand if c.type == "ranged"]
             melee = [c for c in h.hand if c.type == "melee"]
             h.hand.clear()
-            order = ranged + melee
+            order = melee + ranged if is_web else ranged + melee
 
             cancel_next = "cancel" in m.abilities
+
+            dice_count = 0
+            skip_next = False
 
             for card in order:
                 if cancel_next:
@@ -437,33 +556,81 @@ def run_trials(hero_name: str, n: int) -> None:
 
                 dmg = 0
                 count, sides = parse_dice(card.dice)
+                dice_count += count
                 rerolls = 0
+                hits = 0
+                target_def = m.defense
+                card_type = card.type
+                if is_web and card.type == "ranged":
+                    card_type = "melee"
+                if "Aerial Combat" in m.abilities and card_type == "melee":
+                    target_def += 1
                 for _ in range(count):
                     result = random.randint(1, sides)
-                    while (result < m.defense and h.fate > 0 and rerolls < 2 and m.hp <= 2):
+                    while "Denied Heaven" in m.abilities and result == 8:
+                        result = random.randint(1, sides)
+                    while (result < target_def and h.fate > 0 and rerolls < 2 and
+                           m.hp <= 2 and "Disturbed Flow" not in m.abilities):
                         h.fate -= 1
                         rerolls += 1
                         result = random.randint(1, sides)
-                    if result >= m.defense:
+                        while "Denied Heaven" in m.abilities and result == 8:
+                            result = random.randint(1, sides)
+                    if result in (1, 2) and "Curse of Torment" in m.abilities:
+                        prev = h.hp
+                        h.apply_damage(1)
+                        stats["enemy_damage"] += prev - h.hp
+                    if result >= target_def:
                         hit = 2 if random.random() < 0.2 else 1
                         dmg += hit
-                dmg += card.effects.get("damage", 0)
-                arm = card.effects.get("armor", 0)
+                        hits += 1
+                if hits == 0 and "Roots of Despair" in m.abilities:
+                    prev = h.hp
+                    h.apply_damage(1)
+                    stats["enemy_damage"] += prev - h.hp
+
+                if "Silence" not in m.abilities:
+                    dmg += card.effects.get("damage", 0)
+                    arm = card.effects.get("armor", 0)
+                else:
+                    arm = 0
                 h.add_armor(arm)
                 stats["hero_armor"] += arm
+
+                if skip_next:
+                    dmg = 0
+                    skip_next = False
+
                 actual = max(0, dmg - m.armor)
                 m.armor = max(0, m.armor - dmg)
                 m.hp -= actual
                 stats["hero_damage"] += actual
 
-                if "shot" in m.abilities and card.type == "ranged" and m.hp > 0:
+                if "Spiked Armor" in m.abilities and actual >= 3:
+                    prev = h.hp
+                    h.apply_damage(1)
+                    stats["enemy_damage"] += prev - h.hp
+
+                if "shot" in m.abilities and card_type == "ranged" and m.hp > 0:
                     prev_hp = h.hp
                     h.apply_damage(1)
                     stats["enemy_damage"] += prev_hp - h.hp
 
+                if "Ephemeral Wings" in m.abilities and actual > 0:
+                    skip_next = True
+
                 h.discard.append(card)
 
+            if "Banshee Wail" in m.abilities:
+                prev_hp = h.hp
+                h.apply_damage(dice_count // 3)
+                stats["enemy_damage"] += prev_hp - h.hp
+
             dmg, arm = m.roll_action()
+            if "Enrage" in m.abilities and m.hp <= 3:
+                extra_dmg, extra_arm = m.roll_action()
+                dmg += extra_dmg
+                arm += extra_arm
             m.armor += arm
             stats["enemy_armor"] += arm
             if m.hp > 0:
@@ -479,8 +646,13 @@ def run_trials(hero_name: str, n: int) -> None:
                     h.apply_damage(1)
                 stats["enemy_damage"] += prev_hp - h.hp
 
+            leftover = h.armor
             h.reset_armor()
             m.armor = 0
+            if "Cursed Thorns" in m.abilities and leftover > 0:
+                prev_hp = h.hp
+                h.apply_damage(leftover)
+                stats["enemy_damage"] += prev_hp - h.hp
             hero_hp.append(h.hp)
         stats["hero_hp"] = hero_hp
         return stats
@@ -496,7 +668,8 @@ def run_trials(hero_name: str, n: int) -> None:
         hero = Hero(name=hero_name, hp=20,
                     deck=[Card(c.name, c.type, c.dice, c.effects.copy(), c.rarity, c.upgrade)
                           for c in base_deck_fn()])
-        encounters = [Monster(m.name, m.hp, m.defense, m.type, m.abilities.copy())
+        encounters = [Monster(m.name, m.hp, m.defense, m.type,
+                              m.abilities.copy(), m.action_table[:])
                       for m in encounter_list()]
 
         hero.deck = hero.deck[:10]


### PR DESCRIPTION
## Summary
- extend `Monster` with `action_table` and update default roll logic
- provide default tables for basic and elite monsters
- add action tables and simplified ability names for all enemy groups
- implement various monster abilities in combat logic

## Testing
- `python -m py_compile simulator.py`
- `python - <<'PY'
import simulator
simulator.run_trials('Merlin', 1)
PY`