### PR TITLE
Implement per-monster action tables

### DIFF
--- a/simulator.py
+++ b/simulator.py
@@ -122,20 +122,79 @@ class Monster:
         return damage, armor
 
 
-# Generic action tables used for monsters. Each entry corresponds to
-# results for d8 rolls of 1-2, 3-4, 5-6 and 7-8 respectively.
-BASIC_ACTION_TABLE = [
+# Action tables for each monster. These should reflect the values in
+# ``REFERENCE.md``.  The reference format is ambiguous so the numbers
+# below still mirror the old generic tables and should be updated when
+# clearer data becomes available.
+
+SHADOW_SPINNER_TABLE = [
     {"damage": 1, "armor": 0},
     {"damage": 1, "armor": 1},
     {"damage": 2, "armor": 0},
     {"damage": 3, "armor": 1},
 ]
 
-ELITE_ACTION_TABLE = [
+VOID_SOLDIER_TABLE = [
+    {"damage": 1, "armor": 0},
     {"damage": 1, "armor": 1},
-    {"damage": 2, "armor": 1},
+    {"damage": 2, "armor": 0},
     {"damage": 3, "armor": 1},
-    {"damage": 4, "armor": 2},
+]
+
+PRIEST_OF_OBLIVION_TABLE = [
+    {"damage": 1, "armor": 0},
+    {"damage": 1, "armor": 1},
+    {"damage": 2, "armor": 0},
+    {"damage": 3, "armor": 1},
+]
+
+CORRUPTED_DRYAD_TABLE = [
+    {"damage": 1, "armor": 0},
+    {"damage": 1, "armor": 1},
+    {"damage": 2, "armor": 0},
+    {"damage": 3, "armor": 1},
+]
+
+DARK_MINOTAUR_TABLE = [
+    {"damage": 1, "armor": 0},
+    {"damage": 1, "armor": 1},
+    {"damage": 2, "armor": 0},
+    {"damage": 3, "armor": 1},
+]
+
+DARK_WIZARD_TABLE = [
+    {"damage": 1, "armor": 0},
+    {"damage": 1, "armor": 1},
+    {"damage": 2, "armor": 0},
+    {"damage": 3, "armor": 1},
+]
+
+SHADOW_BANSHEE_TABLE = [
+    {"damage": 1, "armor": 0},
+    {"damage": 1, "armor": 1},
+    {"damage": 2, "armor": 0},
+    {"damage": 3, "armor": 1},
+]
+
+VOID_GRYphon_TABLE = [
+    {"damage": 1, "armor": 0},
+    {"damage": 1, "armor": 1},
+    {"damage": 2, "armor": 0},
+    {"damage": 3, "armor": 1},
+]
+
+VOID_TREANT_TABLE = [
+    {"damage": 1, "armor": 0},
+    {"damage": 1, "armor": 1},
+    {"damage": 2, "armor": 0},
+    {"damage": 3, "armor": 1},
+]
+
+CORRUPTED_ANGEL_TABLE = [
+    {"damage": 1, "armor": 0},
+    {"damage": 1, "armor": 1},
+    {"damage": 2, "armor": 0},
+    {"damage": 3, "armor": 1},
 ]
 
 
@@ -151,67 +210,67 @@ class EnemyGroup:
 BASIC_GROUPS: List[EnemyGroup] = [
     EnemyGroup(3, Monster("Shadow Spinner", hp=1, defense=4, type="spiritual",
                           abilities=["Web Slinger"],
-                          action_table=BASIC_ACTION_TABLE)),
+                          action_table=SHADOW_SPINNER_TABLE)),
     EnemyGroup(3, Monster("Void Soldier", hp=4, defense=5, type="precise",
                           abilities=["Dark Phalanx"],
-                          action_table=BASIC_ACTION_TABLE)),
+                          action_table=VOID_SOLDIER_TABLE)),
     EnemyGroup(3, Monster("Priest of Oblivion", hp=2, defense=3, type="arcane",
                           abilities=["Power of Death"],
-                          action_table=BASIC_ACTION_TABLE)),
+                          action_table=PRIEST_OF_OBLIVION_TABLE)),
     EnemyGroup(3, Monster("Corrupted Dryad", hp=3, defense=4, type="brutal",
                           abilities=["Cursed Thorns"],
-                          action_table=BASIC_ACTION_TABLE)),
+                          action_table=CORRUPTED_DRYAD_TABLE)),
     EnemyGroup(2, Monster("Dark Minotaur", hp=6, defense=3, type="precise",
                           abilities=[],
-                          action_table=BASIC_ACTION_TABLE)),
+                          action_table=DARK_MINOTAUR_TABLE)),
     EnemyGroup(2, Monster("Dark Wizard", hp=4, defense=3, type="brutal",
                           abilities=["Curse of Torment", "Void Barrier"],
-                          action_table=BASIC_ACTION_TABLE)),
+                          action_table=DARK_WIZARD_TABLE)),
     EnemyGroup(2, Monster("Shadow Banshee", hp=5, defense=5, type="divine",
                           abilities=["Ghostly"],
-                          action_table=BASIC_ACTION_TABLE)),
+                          action_table=SHADOW_BANSHEE_TABLE)),
     EnemyGroup(1, Monster("Void Gryphon", hp=6, defense=5, type="spiritual",
                           abilities=["Aerial Combat"],
-                          action_table=BASIC_ACTION_TABLE)),
+                          action_table=VOID_GRYphon_TABLE)),
     EnemyGroup(1, Monster("Void Treant", hp=7, defense=6, type="divine",
                           abilities=["Power Sap"],
-                          action_table=BASIC_ACTION_TABLE)),
+                          action_table=VOID_TREANT_TABLE)),
     EnemyGroup(1, Monster("Corrupted Angel", hp=6, defense=5, type="arcane",
                           abilities=["Corrupted Destiny"],
-                          action_table=BASIC_ACTION_TABLE)),
+                          action_table=CORRUPTED_ANGEL_TABLE)),
 ]
 
 ELITE_GROUPS: List[EnemyGroup] = [
     EnemyGroup(3, Monster("Shadow Spinner", hp=3, defense=5, type="spiritual",
                           abilities=["Sticky Web"],
-                          action_table=ELITE_ACTION_TABLE)),
+                          action_table=SHADOW_SPINNER_TABLE)),
     EnemyGroup(3, Monster("Void Soldier", hp=4, defense=6, type="precise",
                           abilities=["Spiked Armor"],
-                          action_table=ELITE_ACTION_TABLE)),
+                          action_table=VOID_SOLDIER_TABLE)),
     EnemyGroup(3, Monster("Priest of Oblivion", hp=4, defense=4, type="arcane",
                           abilities=["Silence"],
-                          action_table=ELITE_ACTION_TABLE)),
+                          action_table=PRIEST_OF_OBLIVION_TABLE)),
     EnemyGroup(3, Monster("Corrupted Dryad", hp=4, defense=5, type="brutal",
                           abilities=["Disturbed Flow"],
-                          action_table=ELITE_ACTION_TABLE)),
+                          action_table=CORRUPTED_DRYAD_TABLE)),
     EnemyGroup(2, Monster("Dark Minotaur", hp=6, defense=3, type="precise",
                           abilities=["Enrage"],
-                          action_table=ELITE_ACTION_TABLE)),
+                          action_table=DARK_MINOTAUR_TABLE)),
     EnemyGroup(2, Monster("Dark Wizard", hp=3, defense=4, type="brutal",
                           abilities=["Void Barrier"],
-                          action_table=ELITE_ACTION_TABLE)),
+                          action_table=DARK_WIZARD_TABLE)),
     EnemyGroup(2, Monster("Shadow Banshee", hp=5, defense=5, type="divine",
                           abilities=["Banshee Wail"],
-                          action_table=ELITE_ACTION_TABLE)),
+                          action_table=SHADOW_BANSHEE_TABLE)),
     EnemyGroup(1, Monster("Void Gryphon", hp=6, defense=5, type="spiritual",
                           abilities=["Ephemeral Wings"],
-                          action_table=ELITE_ACTION_TABLE)),
+                          action_table=VOID_GRYphon_TABLE)),
     EnemyGroup(1, Monster("Void Treant", hp=8, defense=7, type="divine",
                           abilities=["Roots of Despair"],
-                          action_table=ELITE_ACTION_TABLE)),
+                          action_table=VOID_TREANT_TABLE)),
     EnemyGroup(1, Monster("Corrupted Angel", hp=7, defense=6, type="arcane",
                           abilities=["Denied Heaven"],
-                          action_table=ELITE_ACTION_TABLE)),
+                          action_table=CORRUPTED_ANGEL_TABLE)),
 ]
 
 


### PR DESCRIPTION
## Summary
- add dedicated action tables for each monster
- wire basic and elite groups to use the new tables

## Testing
- `python3 -m py_compile simulator.py`