### PR TITLE
Add README and unit tests for card mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Blades of Desolation Prototype
+
+This repository contains a very small prototype for a deterministic card based combat system inspired by Dark Souls. The code in `game.py` implements the round structure described in `design.md`.
+
+## Card System
+
+Heroes fight using a fixed order deck of action cards. At the start of play you choose the order of your 12 cards and draw the top four as your hand. Each card has a speed and stamina cost. When you play a card:
+
+1. The stamina cost is paid from your hero's pool (default 6).
+2. The card is placed in the first slot of a two step cooldown track.
+3. After each round the cooldown slots slide forward. When a card falls off the second slot it is returned to the bottom of the deck and can be drawn again.
+
+This predictable cycle means you always know when a card will return, rewarding careful planning.
+
+## Stamina
+
+Stamina represents your ability to act. Every card has a cost. You regain full stamina each round after cooldown is processed. Running out of stamina limits which cards you can play until it refreshes.
+
+## Enemy Patterns
+
+Enemies use their own small pattern decks. They reveal the next card at the start of each round ("telegraphing" the attack) and step through the deck one card per round, looping back to the beginning when they reach the end. Because the order never changes you can learn and predict enemy behavior.
+
+## Example Round
+
+Below is a brief example showing one round using the default Samurai deck against the Oni.
+
+```
+Starting hand: Iaijutsu Cut, Riposte, Cross-Step, Twin Strikes
+Stamina: 6
+
+Enemy telegraphs: Club Sweep (speed 2, damage 4)
+Target token: A
+
+Hero plays Iaijutsu Cut (speed 3, cost 1)
+Hero acts first and deals 2 damage to the Oni.
+Oni survives and hits back for 3 damage after armor.
+
+Iaijutsu Cut moves to cooldown slot 1.
+Stamina refreshes to 6 and a new card is drawn.
+Enemy deck advances to the next card in its pattern.
+```
+
+Run `python3 game.py` for a tiny command line demo or `python3 -m unittest` to execute the tests.

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,0 +1,46 @@
+import unittest
+from game import Hero, create_samurai_deck, EnemyOni
+
+DEFAULT_ORDER = list(range(1, 13))
+
+class TestGameMechanics(unittest.TestCase):
+    def test_card_play_reduces_stamina_and_enters_cooldown(self):
+        deck = create_samurai_deck(DEFAULT_ORDER)
+        hero = Hero(deck)
+        card = hero.hand[0]
+        prev_stamina = hero.stamina
+        played = hero.play_card(card.id)
+        self.assertEqual(hero.stamina, prev_stamina - card.stamina)
+        self.assertNotIn(played, hero.hand)
+        self.assertIn(played, hero.cooldown[0])
+
+    def test_stamina_refresh_and_cooldown_progression(self):
+        deck = create_samurai_deck(DEFAULT_ORDER)
+        hero = Hero(deck)
+        card = hero.play_card(hero.hand[0].id)
+        hero.end_round()
+        self.assertEqual(hero.stamina, hero.max_stamina)
+        self.assertIn(card, hero.cooldown[1])
+        hero.end_round()
+        # card should be returned to deck and cooldown cleared
+        self.assertNotIn(card, hero.cooldown[0])
+        self.assertNotIn(card, hero.cooldown[1])
+        self.assertIs(hero.deck.cards[-1], card)
+
+    def test_cannot_play_card_without_enough_stamina(self):
+        deck = create_samurai_deck(DEFAULT_ORDER)
+        hero = Hero(deck)
+        card = hero.hand[1]
+        hero.stamina = 0
+        with self.assertRaises(ValueError):
+            hero.play_card(card.id)
+
+    def test_enemy_deck_loops(self):
+        enemy = EnemyOni()
+        first = enemy.telegraph()
+        for _ in range(len(enemy.pattern)):
+            enemy.advance()
+        self.assertEqual(enemy.telegraph(), first)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- document the card system, stamina refresh and enemy patterns
- show an example round in the README
- add unit tests covering card play, cooldown and enemy deck looping

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_6854f278bcb0832aabe1b7b820a64f44