### PR TITLE
Implement Oni Leap Crush area

### DIFF
--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -72,6 +72,16 @@ class TestGameMechanics(unittest.TestCase):
         expected = hp_before - ((atk.damage - hero.armor) * 2)
         self.assertEqual(hero.hp, expected)
 
+    def test_leap_crush_area_on_target(self):
+        deck = create_samurai_deck(DEFAULT_ORDER)
+        hero = Hero(deck)
+        enemy = EnemyOni()
+        atk = OniPatternDeck[1]  # Leap Crush
+        hp_before = hero.hp
+        apply_enemy_attack(hero, hero.hand[0], atk, False, enemy)
+        expected = hp_before - (atk.damage - hero.armor)
+        self.assertEqual(hero.hp, expected)
+
     def test_recuperate_buffs_next_attack(self):
         deck = create_samurai_deck(DEFAULT_ORDER)
         hero = Hero(deck)


### PR DESCRIPTION
## Summary
- support Leap Crush impact areas centered on the hero
- test that Leap Crush properly damages the target

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854fc1e2f58832abdbf95c4700df2b4