### PR TITLE
Enhance battle outcome messaging

### DIFF
--- a/game.py
+++ b/game.py
@@ -599,6 +599,15 @@ def battle() -> None:
         enemy.advance()
         round_no += 1
 
+    if hero.hp > 0 and enemy.hp <= 0:
+        print(f"You defeated the {enemy.name}!")
+    elif hero.hp <= 0 and enemy.hp > 0:
+        print("You were defeated.")
+    elif hero.hp <= 0 and enemy.hp <= 0:
+        print("Both combatants fell.")
+    else:
+        print("The battle ended in a draw.")
+
     print("Battle ended.")
 
 

--- a/tests/test_battle.py
+++ b/tests/test_battle.py
@@ -1,0 +1,41 @@
+import io
+import unittest
+from unittest.mock import patch
+
+import game
+
+class TestBattleOutcome(unittest.TestCase):
+    def test_battle_player_victory_message(self):
+        def dummy_enemy():
+            e = game.EnemyOni()
+            e.hp = 0
+            return e
+
+        with patch('game.prompt_deck_order', return_value=list(range(1, 13))), \
+             patch('game.choose_enemy', dummy_enemy), \
+             patch('sys.stdout', new_callable=io.StringIO) as fake_out:
+            game.battle()
+            output = fake_out.getvalue()
+
+        self.assertIn('You defeated the', output)
+        self.assertIn('Battle ended.', output)
+
+    def test_battle_player_defeat_message(self):
+        class DummyHero(game.Hero):
+            def __init__(self, deck):
+                super().__init__(deck)
+                self.hp = 0
+
+        with patch('game.Hero', DummyHero), \
+             patch('game.prompt_deck_order', return_value=list(range(1, 13))), \
+             patch('sys.stdout', new_callable=io.StringIO) as fake_out:
+            # enemy will be created normally
+            with patch('game.choose_enemy', return_value=game.EnemyOni()):
+                game.battle()
+            output = fake_out.getvalue()
+
+        self.assertIn('You were defeated.', output)
+        self.assertIn('Battle ended.', output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- show win/loss summary when battle ends
- test that battle prints final result messages

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68550ab95bb4832abe758cf1f4f080ab