### PR TITLE
Add minimal Flutter scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ downloads/
 eggs/
 .eggs/
 lib/
+# Allow Flutter projects under mobile_app
+!mobile_app/lib/
 lib64/
 parts/
 sdist/

--- a/mobile_app/.gitignore
+++ b/mobile_app/.gitignore
@@ -1,0 +1,15 @@
+# Flutter/Dart/Pub related
+.dart_tool/
+.packages
+.pub-cache/
+build/
+
+# Flutter generated files
+ios/Flutter/Flutter.framework
+ios/Flutter/Flutter.podspec
+
+# Web related
+web/
+
+# Mac related
+**/*.DS_Store

--- a/mobile_app/README.md
+++ b/mobile_app/README.md
@@ -1,0 +1,5 @@
+# mobile_app
+
+This Flutter project was initialized in a constrained environment. The standard `flutter create` command could not be executed, so only a minimal scaffold is provided.
+
+To fully initialize the project, run `flutter create .` inside this directory once Flutter is installed.

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Demo',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: const MyHomePage(title: 'Flutter Home Page'),
+    );
+  }
+}
+
+class MyHomePage extends StatelessWidget {
+  final String title;
+
+  const MyHomePage({super.key, required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(title),
+      ),
+      body: const Center(
+        child: Text('Hello, Flutter!'),
+      ),
+    );
+  }
+}

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -1,0 +1,19 @@
+name: mobile_app
+description: A new Flutter project.
+publish_to: 'none'
+version: 1.0.0+1
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  cupertino_icons: ^1.0.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/mobile_app/test/widget_test.dart
+++ b/mobile_app/test/widget_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_app/main.dart';
+
+void main() {
+  testWidgets('Smoke test', (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
+    expect(find.text('Hello, Flutter!'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- start a placeholder Flutter project under `mobile_app/`
- exclude `mobile_app/lib` from repo-wide ignore rules

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f937d255c832a9191e3aeefeecda1