### PR TITLE
Add navigation screens and exit button

### DIFF
--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 void main() {
   runApp(const MyApp());
@@ -30,9 +31,93 @@ class MyHomePage extends StatelessWidget {
       appBar: AppBar(
         title: Text(title),
       ),
-      body: const Center(
-        child: Text('Hello, Flutter!'),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ElevatedButton(
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => const ContractsScreen()),
+              ),
+              child: const Text('Contracts'),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => const JourneyScreen()),
+              ),
+              child: const Text('Journey'),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => const MysteryScreen()),
+              ),
+              child: const Text('Mystery'),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => const MonsterScreen()),
+              ),
+              child: const Text('Monster'),
+            ),
+            ElevatedButton(
+              onPressed: () => SystemNavigator.pop(),
+              child: const Text('Close'),
+            ),
+          ],
+        ),
       ),
+    );
+  }
+}
+
+class ContractsScreen extends StatelessWidget {
+  const ContractsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Contracts')),
+      body: const Center(child: Text('Contracts Screen')),
+    );
+  }
+}
+
+class JourneyScreen extends StatelessWidget {
+  const JourneyScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Journey')),
+      body: const Center(child: Text('Journey Screen')),
+    );
+  }
+}
+
+class MysteryScreen extends StatelessWidget {
+  const MysteryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Mystery')),
+      body: const Center(child: Text('Mystery Screen')),
+    );
+  }
+}
+
+class MonsterScreen extends StatelessWidget {
+  const MonsterScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Monster')),
+      body: const Center(child: Text('Monster Screen')),
     );
   }
 }

--- a/mobile_app/test/widget_test.dart
+++ b/mobile_app/test/widget_test.dart
@@ -4,6 +4,6 @@ import 'package:mobile_app/main.dart';
 void main() {
   testWidgets('Smoke test', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
-    expect(find.text('Hello, Flutter!'), findsOneWidget);
+    expect(find.text('Contracts'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- create a home menu with navigation buttons
- add simple screens for Contracts, Journey, Mystery and Monster
- exit the app via `SystemNavigator.pop()` on Close button
- update test to look for new UI

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685f942b0498832a955b87fcdca9b102