### PR TITLE
Add monster detail view

### DIFF
--- a/dndCompanion/assets/data/monsters.json
+++ b/dndCompanion/assets/data/monsters.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "Goblin Raider",
+    "image": "https://placehold.co/100x100.png?text=Goblin",
+    "description": "A sneaky goblin known for ambushing caravans and stealing supplies."
+  },
+  {
+    "name": "Cave Troll",
+    "image": "https://placehold.co/100x100.png?text=Troll",
+    "description": "A massive troll that dwells in dark caves. It is slow but incredibly strong."
+  },
+  {
+    "name": "Mountain Ogre",
+    "image": "https://placehold.co/100x100.png?text=Ogre",
+    "description": "An ogre that roams the mountains looking for unsuspecting travelers to rob."
+  },
+  {
+    "name": "Young Dragon",
+    "image": "https://placehold.co/100x100.png?text=Dragon",
+    "description": "A youthful dragon still learning to use its fiery breath."
+  },
+  {
+    "name": "Phantom Stalker",
+    "image": "https://placehold.co/100x100.png?text=Phantom",
+    "description": "A mysterious spirit that follows adventurers, feeding on their fear."
+  }
+]

--- a/dndCompanion/src/App.js
+++ b/dndCompanion/src/App.js
@@ -6,6 +6,7 @@ import ContractsScreen from './screens/ContractsScreen';
 import JourneyScreen from './screens/JourneyScreen';
 import MysteryScreen from './screens/MysteryScreen';
 import MonsterScreen from './screens/MonsterScreen';
+import MonsterDetailScreen from './screens/MonsterDetailScreen';
 import SearchScreen from './screens/SearchScreen';
 
 const Stack = createStackNavigator();
@@ -20,6 +21,11 @@ export default function App() {
         <Stack.Screen name="Mystery" component={MysteryScreen} />
         <Stack.Screen name="Monster" component={MonsterScreen} />
         <Stack.Screen name="Search" component={SearchScreen} />
+        <Stack.Screen
+          name="MonsterDetail"
+          component={MonsterDetailScreen}
+          options={{headerShown: false}}
+        />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/dndCompanion/src/screens/ContractsScreen.js
+++ b/dndCompanion/src/screens/ContractsScreen.js
@@ -1,24 +1,54 @@
 import React, {useState} from 'react';
-import {View, Text, Button, StyleSheet} from 'react-native';
-import contracts from '../../assets/contracts.json';
+import {
+  View,
+  Text,
+  Button,
+  StyleSheet,
+  Image,
+  TouchableOpacity,
+  ScrollView,
+} from 'react-native';
+import monsters from '../../assets/data/monsters.json';
 
 export default function ContractsScreen({navigation}) {
-  const [contract, setContract] = useState(null);
-  const getRandom = () => {
-    const random = contracts[Math.floor(Math.random() * contracts.length)];
-    setContract(random);
+  const [selected, setSelected] = useState([]);
+
+  const getRandomMonsters = () => {
+    const shuffled = [...monsters].sort(() => 0.5 - Math.random());
+    setSelected(shuffled.slice(0, 4));
+  };
+
+  const openDetails = monster => {
+    navigation.navigate('MonsterDetail', {monster});
   };
 
   return (
     <View style={styles.container}>
-      <Button title="Draw Contract" onPress={getRandom} />
-      {contract && <Text style={styles.text}>{contract}</Text>}
+      <Button title="Draw Monsters" onPress={getRandomMonsters} />
+      <ScrollView contentContainerStyle={styles.list}>
+        {selected.map(monster => (
+          <TouchableOpacity
+            key={monster.name}
+            style={styles.item}
+            onPress={() => openDetails(monster)}>
+            <Image source={{uri: monster.image}} style={styles.thumb} />
+            <Text style={styles.name}>{monster.name}</Text>
+            <Text style={styles.short}>
+              {monster.description.slice(0, 30)}...
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
       <Button title="Back" onPress={() => navigation.goBack()} />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20},
-  text: {marginVertical: 20, textAlign: 'center'},
+  container: {flex: 1, padding: 20},
+  list: {alignItems: 'center', paddingVertical: 20},
+  item: {marginVertical: 10, alignItems: 'center'},
+  thumb: {width: 80, height: 80, marginBottom: 5},
+  name: {fontWeight: 'bold'},
+  short: {textAlign: 'center'},
 });

--- a/dndCompanion/src/screens/MonsterDetailScreen.js
+++ b/dndCompanion/src/screens/MonsterDetailScreen.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  Image,
+  TouchableOpacity,
+  StyleSheet,
+} from 'react-native';
+
+export default function MonsterDetailScreen({route, navigation}) {
+  const {monster} = route.params;
+
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity
+        style={styles.backButton}
+        onPress={() => navigation.goBack()}>
+        <Text style={styles.backText}>Back</Text>
+      </TouchableOpacity>
+      <TouchableOpacity onPress={() => navigation.goBack()} style={styles.imageWrapper}>
+        <Image
+          source={{uri: monster.image}}
+          style={styles.image}
+          resizeMode="contain"
+        />
+      </TouchableOpacity>
+      <Text style={styles.description}>{monster.description}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {flex: 1, backgroundColor: '#000', justifyContent: 'center'},
+  backButton: {position: 'absolute', top: 40, left: 20, zIndex: 1},
+  backText: {color: '#fff'},
+  imageWrapper: {flex: 1, justifyContent: 'center'},
+  image: {width: '100%', height: '100%'},
+  description: {color: '#fff', textAlign: 'center', padding: 20},
+});


### PR DESCRIPTION
## Summary
- add custom monsters with remote images in a new data file
- show four random monsters in `ContractsScreen`
- tapping a monster opens a fullscreen detail screen
- add `MonsterDetailScreen` to navigation stack

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f9596fbc8832ab50898986c17df03