### PR TITLE
Add journey cards feature

### DIFF
--- a/dndCompanion/assets/data/journey_cards.json
+++ b/dndCompanion/assets/data/journey_cards.json
@@ -1,0 +1,12 @@
+[
+  {"id": 1, "text": "Venture across the perilous mountains", "image": "https://placehold.co/200x120.png?text=Journey+1"},
+  {"id": 2, "text": "Sail the treacherous seas to the Storm Isle", "image": "https://placehold.co/200x120.png?text=Journey+2"},
+  {"id": 3, "text": "Escort a caravan through the haunted woods", "image": "https://placehold.co/200x120.png?text=Journey+3"},
+  {"id": 4, "text": "Traverse the scorching desert in search of ruins", "image": "https://placehold.co/200x120.png?text=Journey+4"},
+  {"id": 5, "text": "Cross the frozen tundra to reach the northern outpost", "image": "https://placehold.co/200x120.png?text=Journey+5"},
+  {"id": 6, "text": "Navigate the dense jungle for a lost temple", "image": "https://placehold.co/200x120.png?text=Journey+6"},
+  {"id": 7, "text": "Climb the cliffs to the dragon's lair", "image": "https://placehold.co/200x120.png?text=Journey+7"},
+  {"id": 8, "text": "Ride the plains to deliver urgent news", "image": "https://placehold.co/200x120.png?text=Journey+8"},
+  {"id": 9, "text": "Follow the mysterious river to its source", "image": "https://placehold.co/200x120.png?text=Journey+9"},
+  {"id": 10, "text": "Descend into the underdark seeking allies", "image": "https://placehold.co/200x120.png?text=Journey+10"}
+]

--- a/dndCompanion/src/screens/JourneyScreen.js
+++ b/dndCompanion/src/screens/JourneyScreen.js
@@ -1,24 +1,48 @@
-import React, {useState} from 'react';
-import {View, Text, Button, StyleSheet} from 'react-native';
-import journeys from '../../assets/journeys.json';
+import React, {useState, useEffect} from 'react';
+import {View, Text, Button, StyleSheet, Image} from 'react-native';
+import cards from '../../assets/data/journey_cards.json';
 
 export default function JourneyScreen({navigation}) {
-  const [journey, setJourney] = useState(null);
-  const getRandom = () => {
-    const random = journeys[Math.floor(Math.random() * journeys.length)];
-    setJourney(random);
+  const [card, setCard] = useState(null);
+  const [recentIds, setRecentIds] = useState([]);
+
+  const drawCard = () => {
+    const available = cards.filter(c => !recentIds.includes(c.id));
+    const next =
+      available.length > 0
+        ? available[Math.floor(Math.random() * available.length)]
+        : cards[Math.floor(Math.random() * cards.length)];
+
+    setCard(next);
+    setRecentIds(prev => {
+      const updated = [next.id, ...prev];
+      if (updated.length > 10) {
+        updated.pop();
+      }
+      return updated;
+    });
   };
+
+  useEffect(() => {
+    drawCard();
+  }, []);
 
   return (
     <View style={styles.container}>
-      <Button title="Draw Journey" onPress={getRandom} />
-      {journey && <Text style={styles.text}>{journey}</Text>}
-      <Button title="Back" onPress={() => navigation.goBack()} />
+      {card && (
+        <>
+          <Image source={{uri: card.image}} style={styles.image} />
+          <Text style={styles.text}>{card.text}</Text>
+        </>
+      )}
+      <Button title="Next" onPress={drawCard} />
+      <Button title="Back to Home" onPress={() => navigation.popToTop()} />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20},
+  image: {width: 200, height: 120, marginBottom: 10},
   text: {marginVertical: 20, textAlign: 'center'},
 });


### PR DESCRIPTION
## Summary
- add `assets/data/journey_cards.json`
- update `JourneyScreen` to pick cards from new dataset
- show image and text with Next and Home buttons
- keep a list of the last 10 cards to avoid repeats

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f9d17e980832a9036f7473207f6b7