### PR TITLE
Add mystery cards feature

### DIFF
--- a/dndCompanion/assets/data/mystery_cards.json
+++ b/dndCompanion/assets/data/mystery_cards.json
@@ -1,0 +1,12 @@
+[
+  {"id": 1, "text": "Who stole the ancient crown?", "image": "https://placehold.co/200x120.png?text=Mystery+1"},
+  {"id": 2, "text": "Why is the village cursed?", "image": "https://placehold.co/200x120.png?text=Mystery+2"},
+  {"id": 3, "text": "What lies beneath the ruins?", "image": "https://placehold.co/200x120.png?text=Mystery+3"},
+  {"id": 4, "text": "Who is the masked stranger?", "image": "https://placehold.co/200x120.png?text=Mystery+4"},
+  {"id": 5, "text": "Where did the lost caravan go?", "image": "https://placehold.co/200x120.png?text=Mystery+5"},
+  {"id": 6, "text": "What creature roams the sewers?", "image": "https://placehold.co/200x120.png?text=Mystery+6"},
+  {"id": 7, "text": "Who opened the forbidden vault?", "image": "https://placehold.co/200x120.png?text=Mystery+7"},
+  {"id": 8, "text": "Why are the dead rising?", "image": "https://placehold.co/200x120.png?text=Mystery+8"},
+  {"id": 9, "text": "What dark power sleeps in the forest?", "image": "https://placehold.co/200x120.png?text=Mystery+9"},
+  {"id": 10, "text": "Who betrayed the guild?", "image": "https://placehold.co/200x120.png?text=Mystery+10"}
+]

--- a/dndCompanion/src/screens/MysteryScreen.js
+++ b/dndCompanion/src/screens/MysteryScreen.js
@@ -1,24 +1,48 @@
-import React, {useState} from 'react';
-import {View, Text, Button, StyleSheet} from 'react-native';
-import mysteries from '../../assets/mysteries.json';
+import React, {useState, useEffect} from 'react';
+import {View, Text, Button, StyleSheet, Image} from 'react-native';
+import cards from '../../assets/data/mystery_cards.json';
 
 export default function MysteryScreen({navigation}) {
-  const [mystery, setMystery] = useState(null);
-  const getRandom = () => {
-    const random = mysteries[Math.floor(Math.random() * mysteries.length)];
-    setMystery(random);
+  const [card, setCard] = useState(null);
+  const [recentIds, setRecentIds] = useState([]);
+
+  const drawCard = () => {
+    const available = cards.filter(c => !recentIds.includes(c.id));
+    const next =
+      available.length > 0
+        ? available[Math.floor(Math.random() * available.length)]
+        : cards[Math.floor(Math.random() * cards.length)];
+
+    setCard(next);
+    setRecentIds(prev => {
+      const updated = [next.id, ...prev];
+      if (updated.length > 10) {
+        updated.pop();
+      }
+      return updated;
+    });
   };
+
+  useEffect(() => {
+    drawCard();
+  }, []);
 
   return (
     <View style={styles.container}>
-      <Button title="Draw Mystery" onPress={getRandom} />
-      {mystery && <Text style={styles.text}>{mystery}</Text>}
-      <Button title="Back" onPress={() => navigation.goBack()} />
+      {card && (
+        <>
+          <Image source={{uri: card.image}} style={styles.image} />
+          <Text style={styles.text}>{card.text}</Text>
+        </>
+      )}
+      <Button title="Next" onPress={drawCard} />
+      <Button title="Back to Home" onPress={() => navigation.popToTop()} />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20},
+  image: {width: 200, height: 120, marginBottom: 10},
   text: {marginVertical: 20, textAlign: 'center'},
 });


### PR DESCRIPTION
## Summary
- store new mystery cards data
- make MysteryScreen load cards and behave like JourneyScreen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685fa3f71d24832ab1a3e2a3d7d338f7