### PR TITLE
Deeper Spellrift simulator: 7-room Monte Carlo with seals, boons, taint & conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ python3 spellrift_balance_sim.py --sims 20000 --seed 42
 ```
 
 Use `--sims` to configure the number of simulation runs.
+Use `--max-rounds-safety` to cap pathological long combats in the abstract model.

--- a/SIM_GDD_GAP_PLAN.md
+++ b/SIM_GDD_GAP_PLAN.md
@@ -1,304 +1,45 @@
-# Spellrift Simulator vs GDD v0.4.2 — Gap Analysis and Implementation Plan
+# Spellrift Simulator — Remaining Fidelity Gaps (Post-Implementation)
 
-This document audits `spellrift_balance_sim.py` against the provided GDD and lists what is **not implemented** or only **partially implemented**, plus a concrete plan to implement each gap.
+This repository now includes a substantially upgraded simulation model in `spellrift_balance_sim.py`:
+- finite shuffled gate/room decks per run,
+- initiative + round flow,
+- seals (banking/channeling) and fragment claim costs,
+- hero LP/special/dice resolution,
+- condition escalation/opposition + surge cleanups,
+- villain level scaling and core villain effects,
+- room-wise outputs (HP, hero damage, taint) and boon CP contributions.
 
-## Legend
-- **Implemented**: present and materially aligned.
-- **Partial**: present but simplified/approximate.
-- **Missing**: absent.
+## Still needed for a fully faithful v0.4.2 simulator
 
----
+1. **Full Boon card fidelity**
+   - Only a representative subset of each color deck is modeled.
+   - Many conditional effects (Ruin/Chain/Assassinate edge cases) are still abstracted.
 
-## 1) Global Architecture and Run Structure
+2. **Full room card fidelity**
+   - Room roster coverage is partial (representative entries for Basic/Temple/Nexus).
+   - Several room rules and Eye Omens are approximated as probabilistic pressure effects.
 
-### Gaps
-1. **Deck-state continuity not modeled exactly** (Gate/Room/Boon decks are sampled each time, not finite shuffled decks per run).  
-   Status: **Partial**.
-2. **Room card identity and Room rule text not explicitly represented**.  
-   Status: **Missing**.
-3. **No mission-level boss flow (Void Essence >=3, summon boss, boss deck)**.  
-   Status: **Missing**.
-4. **No Return to Base / retreat loop and multi-run progression behavior**.  
-   Status: **Missing**.
+3. **Hero utility + unique powers, full detail**
+   - Modeled partially/abstractly (especially Merlin runes); still missing complete behavior for Titan Grip, Oriflamme zone logic, and Golden Webway interactions.
 
-### Plan
-- Build a `RunState` with explicit shuffled deck objects: `standard_gate_deck`, `nexus_gate_deck`, `basic_room_deck`, `temple_room_deck`, `altar_room_deck`, and 5 boon decks.
-- On each room, perform exact card draws/discards and exhaustion behavior.
-- Add room-card data model with:
-  - tile id (for future geometry if needed)
-  - spawn lists by threat
-  - room rule callback.
-- Add mission-phase state machine:
-  - pre-boss rooms → Nexus clears grant essence → optional boss summon.
-- Add retreat policy abstraction (AI policy) and post-retreat effects.
+4. **Boss phase and Void Essence flow**
+   - Current simulation targets the requested 7-room room-by-room analysis and does not execute boss encounter logic.
 
----
+5. **Exact task-based fragment claims**
+   - Task triggers are probabilistic, not event-proofed against full positional predicates.
 
-## 2) Initiative, Rounds, and Turn Timing
+6. **Range/adjacency predicates under movement simplification**
+   - Effects that depend on strict geometry are translated to average-case probabilities.
 
-### Gaps
-1. **Single initiative line exists, but many start/end timing hooks omitted** (start-of-round room effects, first-time-per-round triggers, etc.).  
-   Status: **Partial**.
-2. **Round cap (currently hard cap at 8) is simulator-imposed, not in GDD**.  
-   Status: **Partial**.
+7. **Temple exchange policy AI**
+   - Temple exchanges are represented as heuristics, not explicit option optimization per state.
 
-### Plan
-- Add event bus hooks for timings:
-  - `on_room_start`, `on_round_start`, `on_turn_start`, `on_pre_attack`, `on_post_attack`, `on_turn_end`, `on_round_end`, `on_room_end`.
-- Replace hard round cap with configurable fail-safe (`--max-rounds-safety`) and report when safety triggers.
+## Why this is still useful now
 
----
+The current simulator already produces the requested Monte Carlo outputs at 20,000 runs:
+- average HP per hero at end of each room (1..7),
+- average damage dealt by each hero per room,
+- average CP contribution per boon card,
+- average taint per room.
 
-## 3) Movement, Position, Terrain, LOS
-
-> The user asked to simplify movement/grid and assume average engagement. This is intentionally omitted.  
-> However, several mechanics still depend on adjacency/range/flank/isolated.
-
-### Gaps
-1. **No explicit abstract distance model for adjacency/range dependent mechanics**.  
-   Status: **Missing**.
-2. **Flanking, Isolated, threatened movement events are not represented in an abstract probabilistic way**.  
-   Status: **Partial/Missing**.
-3. **No LOS abstraction for ranged constraints**.  
-   Status: **Missing**.
-
-### Plan
-- Add an **abstract engagement state** per combatant pair with probabilities:
-  - adjacent probability
-  - isolated probability
-  - flank probability
-  - ranged-LOS probability.
-- Parameterize by room archetype/threat and allow calibration from playtest logs.
-- Use these probabilities to gate effects (flank bonus, isolated bonuses, chain range validity, etc.) without full grid simulation.
-
----
-
-## 4) Hero Kits (Attacks, Utility, Unique Powers)
-
-### Gaps
-1. **Utilities mostly not modeled** (Heroic Leap, Wyrd Weaver multi-use, Lay on Hands, Nudge the Story).  
-   Status: **Missing**.
-2. **Unique powers mostly not modeled**:
-   - Hercules Titan Grip.  
-   - Merlin Rune Writing and rune-slot flow/overflow.  
-   - Joan Oriflamme free-reroll aura.  
-   - Anansi Golden Webway armor/teleport behavior.  
-   Status: **Missing**.
-3. **Many attack-specific effects omitted or simplified** (multi-target assignment, pull/push prerequisites, chain lightning details, etc.).  
-   Status: **Partial**.
-
-### Plan
-- Implement per-hero strategy modules with action priority including utility usage.
-- Add support for non-damage effect primitives: `push`, `pull`, `knockback`, `chain`, `heal`, `grant_condition`, `grant_armor`, `reroll_grant`.
-- Add state containers:
-  - Hercules held-target slot
-  - Merlin rune slots + completed spell resolver
-  - Joan oriflamme zone state (abstractly represented)
-  - Anansi two web markers (abstract usage chances + armor effects).
-
----
-
-## 5) Villain AI and Villain Effects
-
-### Gaps
-1. **Targeting rules partially implemented** (closest approximated via low HP fallback).  
-   Status: **Partial**.
-2. **Movement/path preference logic omitted** (threatened movement, dangerous terrain avoidance)—acceptable under movement simplification, but needs abstract substitute.  
-   Status: **Missing (abstract)**.
-3. **Some villain effects simplified or missing** (Banshee terror push all combatants, Dark Wizard push, Treant exact splash radius behavior).  
-   Status: **Partial**.
-4. **Elite +1 level behavior for elite-tagged spawns not modeled at spawn-card level**.  
-   Status: **Missing**.
-
-### Plan
-- Build effect functions per villain with explicit trigger timing.
-- Add abstract “secondary target exposure probability” for AoE effects.
-- Introduce room spawn metadata with elite flags and level override at spawn time.
-
----
-
-## 6) Conditions System
-
-### Gaps
-1. **Two-sided condition escalation (front/back) and anti-stacking logic not fully implemented**.  
-   Status: **Missing**.
-2. **Opposing pair cancellation ladder not implemented**.  
-   Status: **Missing**.
-3. **Duration rules incomplete** (until healed, until next move, next surge, etc.).  
-   Status: **Partial/Missing**.
-4. **Positive/Negative classification and surge cleanup only partly used**.  
-   Status: **Partial**.
-
-### Plan
-- Replace raw `Counter` with structured `ConditionState`:
-  - tier (none/front/back)
-  - expiry mode (`surge`, `on_heal`, `next_move`, `next_turn_end`, persistent).
-- Implement opposing-pair resolver function and condition transition table.
-
----
-
-## 7) Seals and Unseal Economy
-
-### Gaps
-1. **Seal banking and claim-cost flow are partial** (channeling 2 same-color seals for +1 special absent).  
-   Status: **Partial**.
-2. **Merlin rune-slot interaction with banking absent**.  
-   Status: **Missing**.
-3. **Seal cap overflow handling (Merlin overflow) absent**.  
-   Status: **Missing**.
-
-### Plan
-- Add Seal subsystem with three APIs:
-  - `bank_special(hero, color)`
-  - `spend_for_fragment(color)`
-  - `channel_into_roll(color)`.
-- Integrate hero-specific override for Merlin banking destination.
-
----
-
-## 8) Fragments, Tasks, and Boon Drafting
-
-### Gaps
-1. **Fragment task triggers by color are not modeled (red/blue/green/grey/yellow tasks).**  
-   Status: **Missing**.
-2. **Claim by action vs by task distinction not modeled.**  
-   Status: **Missing**.
-3. **LP-paid extra draft cards (+1 up to +3) not modeled.**  
-   Status: **Missing**.
-4. **Exact boon deck draw/discard order and depletion behavior not modeled.**  
-   Status: **Partial**.
-
-### Plan
-- Add task event detectors and allow out-of-turn fragment claims.
-- Implement draft flow exactly:
-  - draw 3
-  - optional LP spend for extra cards
-  - keep 1, bottom rest in chosen order (policy heuristic).
-- Maintain finite boon decks and reshuffle rules if desired.
-
----
-
-## 9) Gate and Room Rules Coverage
-
-### Gaps
-1. **Most gate rule text effects are not implemented** (reroll bans, first-round armor ignore, dampening field, bloody fate, etc.).  
-   Status: **Mostly Missing**.
-2. **Temple exchange options not modeled.**  
-   Status: **Missing**.
-3. **Basic room blessings and altar eye omens mostly not modeled.**  
-   Status: **Missing**.
-
-### Plan
-- Convert gate/room effects into data-driven modifiers:
-  - passive constraints
-  - one-time triggers
-  - per-round triggers.
-- Implement each gate rule as a tested effect function.
-- Add temple decision policy engine for exchange options.
-
----
-
-## 10) Boon Card Fidelity
-
-### Gaps
-1. **Boon set includes simplified projections, not full exact text behavior**.  
-   Status: **Partial**.
-2. **Many keyword mechanics absent/incomplete in boon resolution**:
-   - Chain Lightning, Life Wave, Ruin chaining, Inspire, Bulwark, Assassinate logic.
-   Status: **Partial/Missing**.
-3. **Cards with placeholder/no effect are included but not distinguished for analytics quality.**  
-   Status: **Partial**.
-
-### Plan
-- Encode boon cards as declarative effect specs with reusable keyword resolvers.
-- Add coverage tests per keyword to ensure deterministic trigger accounting.
-- Report confidence labels per boon contribution:
-  - exact, approximated, placeholder.
-
----
-
-## 11) Damage Math and Type Handling
-
-### Gaps
-1. **Mixed-type damage separation for vulnerability/resistance is simplified** (single dominant type heuristic).  
-   Status: **Partial**.
-2. **Multi-target attacks with per-die assignment not implemented.**  
-   Status: **Missing**.
-
-### Plan
-- Keep per-die color outcomes in a typed damage bucket map.
-- Apply vulnerability/resistance per type, then armor, then sum.
-- For multi-target attacks, add assignment policy solver (greedy by kill-probability).
-
----
-
-## 12) Taint, Despair, Surge, Collapse
-
-### Gaps
-1. **Core taint/despair/surge modeled, but not all taint modifiers from gate/room/temple effects.**  
-   Status: **Partial**.
-2. **Collapse handling approximated; needs strict end-of-next-round loss semantics tied to boss/escape conditions.**  
-   Status: **Partial**.
-
-### Plan
-- Centralize taint changes via `apply_taint(delta, reason)` to ensure all effects route through one system.
-- Implement strict collapse timeline with explicit countdown state.
-
----
-
-## 13) Output and Analysis Quality
-
-### Gaps
-1. **Required outputs are present, but confidence/variance intervals missing.**  
-   Status: **Partial**.
-2. **No per-room win rate / room clear probability / death counts by hero diagnostics.**  
-   Status: **Missing**.
-3. **No calibration tooling against real playtest logs.**  
-   Status: **Missing**.
-
-### Plan
-- Add 95% confidence intervals for all reported averages.
-- Add diagnostics table:
-  - room clear rate
-  - hero death incidence
-  - average rounds per room
-  - seal usage and taint-source breakdown.
-- Add optional CSV/JSON export for plotting.
-
----
-
-## 14) Recommended Implementation Sequence
-
-### Phase 1 — Rules-Core Accuracy (highest impact)
-1. Structured condition engine.
-2. Typed damage buckets + vulnerability/resistance correctness.
-3. Exact seal subsystem (including channeling).
-4. Task-based fragment claims + exact draft flow.
-
-### Phase 2 — Content Coverage
-5. Gate rules complete implementation.
-6. Basic room blessings and altar omens.
-7. Temple exchanges with policy AI.
-8. Elite spawn tags and room-card specific spawns.
-
-### Phase 3 — Hero/Villain Fidelity
-9. Hero utilities and unique powers.
-10. Villain special effects full behavior.
-11. Multi-target and keyword effect engine.
-
-### Phase 4 — Mission Loop and Analytics
-12. Void Essence + boss flow + retreat loop.
-13. Confidence intervals and richer telemetry.
-14. Calibration hooks and parameter tuning pipeline.
-
----
-
-## 15) Definition of Done for “Faithful Simulation”
-
-A simulator version should be considered faithful when:
-1. All gate rules, room rules, and villain/hero powers are represented by explicit tested mechanics.
-2. Condition transitions and durations match the rulebook tables.
-3. Damage typing and special-spend rules match card text semantics.
-4. Deck draws are finite and reproducible with deterministic seeds.
-5. Report contains required averages plus uncertainty and event-source diagnostics.
-
+This gives balance-directional data while preserving runtime practicality and avoiding a full grid/physics simulation.

--- a/spellrift_balance_sim.py
+++ b/spellrift_balance_sim.py
@@ -1,37 +1,49 @@
 #!/usr/bin/env python3
-"""
-Spellrift Dungeons alpha balance simulator (v0.4.2-inspired).
+"""Spellrift Dungeons alpha simulator (abstracted positionless model).
 
-Scope:
-- Simulates 4 fixed heroes through up to 7 rooms.
-- Ignores board movement/grid/LOS details by assumption (average engagement model).
-- Models dice, specials, LP, initiative, seals, taint/surges, villain attacks, conditions,
-  gate/room selection, fragment -> boon drafting, and monster level scaling.
-- Runs Monte Carlo and reports room-wise averages and boon CP contribution.
-
-This is an approximation engine intended for balance exploration, not a strict rules validator.
+This simulator intentionally ignores grid movement/terrain geometry, but models:
+- initiative and per-turn flow
+- hero attacks, LP economy, specials, rerolls, seals and seal channeling
+- gate + room draw loop with finite shuffled decks per run
+- villain attacks, level scaling, core villain effects
+- condition escalation/opposition and surge cleanup
+- fragment claiming + boon drafting
+- room-wise aggregates up to room 7 over Monte Carlo runs
 """
 
 from __future__ import annotations
 
+from collections import Counter, defaultdict
 from dataclasses import dataclass, field
-from collections import defaultdict, Counter
 import random
 import statistics
 from typing import Dict, List, Optional, Tuple
 
-# ---------- Combat point model (from GDD section 21) ----------
 CP_DAMAGE = 1.0
-CP_HP = 1.0
 CP_LP = 1.0
-CP_ARMOR = 1.5
-CP_DIE = 3.0
-CP_SPECIAL_COST = 2.0
-
 MAX_ROOMS = 7
 DEFAULT_SIMS = 20_000
 
-COLORS = ["red", "green", "grey", "blue", "yellow"]
+POSITIVE_CONDS = {"empowered", "exalted", "toughened", "armored"}
+NEGATIVE_CONDS = {"weakened", "enfeebled", "exposed", "breached", "bleeding", "hemorrhaging", "staggered", "slowed"}
+CONDITION_LADDERS = {
+    "weakened": ["weakened", "enfeebled"],
+    "empowered": ["empowered", "exalted"],
+    "toughened": ["toughened", "armored"],
+    "exposed": ["exposed", "breached"],
+    "bleeding": ["bleeding", "hemorrhaging"],
+    "slowed": ["slowed", "staggered"],
+}
+OPPOSING = {
+    "weakened": "empowered",
+    "enfeebled": "exalted",
+    "empowered": "weakened",
+    "exalted": "enfeebled",
+    "toughened": "exposed",
+    "armored": "breached",
+    "exposed": "toughened",
+    "breached": "armored",
+}
 
 
 @dataclass
@@ -40,55 +52,17 @@ class Attack:
     base_dice: Dict[str, int]
     lp_cost: int = 0
     lp_gain: int = 0
-    range_type: str = "melee"  # only used for heuristics
-    special_rules: Dict[str, int] = field(default_factory=dict)
     full_spender: bool = False
+    range_type: str = "melee"
+    special_rules: Dict[str, int] = field(default_factory=dict)
 
 
 @dataclass
 class HeroTemplate:
     name: str
     max_hp: int
-    attacks: List[Attack]
     relic_die_color: str
-
-
-@dataclass
-class VillainTemplate:
-    name: str
-    hp: int
-    armor: int
-    damage: int
-    target_rule: str
-    vulnerability: Optional[str]
-    resistance: Optional[str] = None
-    effects: Tuple[str, ...] = ()
-
-
-@dataclass
-class Boon:
-    name: str
-    color: str
-    dice_bonus: Dict[str, int] = field(default_factory=dict)
-    # tiny subset of effects modeled consistently across cards
-    on_attack_flat_bonus: int = 0
-    on_color_special_bonus_damage: Dict[str, int] = field(default_factory=dict)
-    on_color_special_bonus_lp: Dict[str, int] = field(default_factory=dict)
-    on_kill_lp: int = 0
-
-
-@dataclass
-class Enemy:
-    template: VillainTemplate
-    hp: int
-    armor: int
-    damage: int
-    level: int
-    conditions: Counter = field(default_factory=Counter)
-
-    @property
-    def alive(self) -> bool:
-        return self.hp > 0
+    attacks: List[Attack]
 
 
 @dataclass
@@ -98,9 +72,37 @@ class HeroState:
     lp: int = 0
     armor: int = 0
     alive: bool = True
-    conditions: Counter = field(default_factory=Counter)
-    boons: List[Boon] = field(default_factory=list)
+    conditions: set[str] = field(default_factory=set)
+    boons: List["Boon"] = field(default_factory=list)
     damage_done_this_room: float = 0.0
+    reroll_free_this_round: bool = False
+    first_attack_this_round: bool = True
+    rune_slots: List[str] = field(default_factory=list)
+
+
+@dataclass
+class VillainTemplate:
+    name: str
+    hp: int
+    armor: int
+    damage: int
+    target_rule: str
+    vulnerability: Optional[str] = None
+    effects: Tuple[str, ...] = ()
+
+
+@dataclass
+class Enemy:
+    template: VillainTemplate
+    hp: int
+    armor: int
+    damage: int
+    level: int
+    conditions: set[str] = field(default_factory=set)
+
+    @property
+    def alive(self) -> bool:
+        return self.hp > 0
 
 
 @dataclass
@@ -111,91 +113,81 @@ class Gate:
     fragments: List[str]
     start_lp: int = 0
     start_heal: int = 0
+    rule_tag: str = "none"
 
 
-# ---------- Data: heroes ----------
-HEROES: List[HeroTemplate] = [
-    HeroTemplate(
-        "Hercules",
-        25,
-        [
-            Attack("Pillar-Breaker Blow", {"red": 3}, lp_gain=1, special_rules={"red": 1}),
-            Attack("Club Spin", {"green": 2}, lp_gain=2, special_rules={"green": 1}),
-            Attack("Colossus Smash", {"red": 4}, lp_cost=2, special_rules={"red": 2}),
-            Attack("True Might", {"yellow": 4, "red": 3}, lp_cost=3, full_spender=True),
-        ],
-        relic_die_color="red",
-    ),
-    HeroTemplate(
-        "Merlin",
-        18,
-        [
-            Attack("Arcane Volley", {"blue": 2}, lp_gain=1, range_type="ranged", special_rules={"blue": 1}),
-            Attack("Spiritual Gifts", {"grey": 2}, lp_gain=2, range_type="ranged"),
-            Attack("Whispers of the Wyrd", {"grey": 2}, lp_cost=2, range_type="ranged"),
-            Attack("Avalon's Light", {"blue": 7}, lp_cost=3, full_spender=True),
-        ],
-        relic_die_color="blue",
-    ),
-    HeroTemplate(
-        "Joan d’Arc",
-        20,
-        [
-            Attack("Blade of Lys", {"yellow": 1, "red": 2}, lp_gain=1, special_rules={"yellow": 1, "red": 1}),
-            Attack("Holy Bolt", {"yellow": 2}, lp_gain=2, range_type="ranged", special_rules={"yellow": 1}),
-            Attack("Vanguard Strike", {"red": 3}, lp_cost=3, range_type="ranged"),
-            Attack("Divine Punishment", {"yellow": 4}, lp_cost=3, full_spender=True),
-        ],
-        relic_die_color="yellow",
-    ),
-    HeroTemplate(
-        "Anansi",
-        20,
-        [
-            Attack("Guile Strike", {"green": 2}, lp_gain=1, special_rules={"green": 1}),
-            Attack("Story-weaver", {"yellow": 2}, lp_gain=2, special_rules={"yellow": 1}),
-            Attack("Snare and Sever", {"green": 3, "blue": 2}, lp_cost=2, range_type="ranged", special_rules={"green": 2}),
-            Attack("The Last Thread", {"green": 3}, lp_cost=3, full_spender=True),
-        ],
-        relic_die_color="green",
-    ),
+@dataclass
+class RoomCard:
+    name: str
+    room_type: str
+    spawns_by_threat: Dict[int, List[Tuple[str, bool]]]
+    rule_tag: str = "none"
+
+
+@dataclass
+class Boon:
+    name: str
+    color: str
+    dice_bonus: Dict[str, int] = field(default_factory=dict)
+    on_attack_flat_bonus: int = 0
+    on_color_special_bonus_damage: Dict[str, int] = field(default_factory=dict)
+    on_color_special_bonus_lp: Dict[str, int] = field(default_factory=dict)
+    on_kill_lp: int = 0
+
+
+HEROES = [
+    HeroTemplate("Hercules", 25, "red", [
+        Attack("Pillar-Breaker Blow", {"red": 3}, lp_gain=1, special_rules={"red": 1}),
+        Attack("Club Spin", {"green": 2}, lp_gain=2, special_rules={"green": 1}),
+        Attack("Colossus Smash", {"red": 4}, lp_cost=2, special_rules={"red": 2}),
+        Attack("True Might", {"yellow": 4, "red": 3}, lp_cost=3, full_spender=True),
+    ]),
+    HeroTemplate("Merlin", 18, "blue", [
+        Attack("Arcane Volley", {"blue": 2}, lp_gain=1, range_type="ranged", special_rules={"blue": 1}),
+        Attack("Spiritual Gifts", {"grey": 2}, lp_gain=2, range_type="ranged", special_rules={"grey": 1}),
+        Attack("Whispers of the Wyrd", {"grey": 2}, lp_cost=2, range_type="ranged"),
+        Attack("Avalon's Light", {"blue": 7}, lp_cost=3, full_spender=True),
+    ]),
+    HeroTemplate("Joan d’Arc", 20, "yellow", [
+        Attack("Blade of Lys", {"yellow": 1, "red": 2}, lp_gain=1, special_rules={"yellow": 1, "red": 1}),
+        Attack("Holy Bolt", {"yellow": 2}, lp_gain=2, range_type="ranged", special_rules={"yellow": 1}),
+        Attack("Vanguard Strike", {"red": 3}, lp_cost=3, range_type="ranged"),
+        Attack("Divine Punishment", {"yellow": 4}, lp_cost=3, full_spender=True),
+    ]),
+    HeroTemplate("Anansi", 20, "green", [
+        Attack("Guile Strike", {"green": 2}, lp_gain=1, special_rules={"green": 1}),
+        Attack("Story-weaver", {"yellow": 2}, lp_gain=2, special_rules={"yellow": 1}),
+        Attack("Snare and Sever", {"green": 3, "blue": 2}, lp_cost=2, range_type="ranged", special_rules={"green": 2}),
+        Attack("The Last Thread", {"green": 3}, lp_cost=3, full_spender=True),
+    ]),
 ]
 
-
-VILLAINS: Dict[str, VillainTemplate] = {
-    "Voidling": VillainTemplate("Voidling", hp=2, armor=0, damage=2, target_rule="closest", vulnerability=None, effects=("drain_lp",)),
-    "Shadow Spinner": VillainTemplate("Shadow Spinner", hp=4, armor=0, damage=3, target_rule="low_hp", vulnerability="red", effects=("staggered",)),
-    "Void Soldier": VillainTemplate("Void Soldier", hp=5, armor=0, damage=3, target_rule="closest", vulnerability="blue", effects=("self_toughened",)),
-    "Dark Wizard": VillainTemplate("Dark Wizard", hp=10, armor=1, damage=3, target_rule="high_hp", vulnerability="yellow", effects=("ignore_armor",)),
-    "Shadow Banshee": VillainTemplate("Shadow Banshee", hp=10, armor=0, damage=4, target_rule="high_lp", vulnerability="grey", effects=("terror",)),
-    "Void Treant": VillainTemplate("Void Treant", hp=12, armor=2, damage=3, target_rule="closest", vulnerability="green", effects=("splash",)),
+VILLAINS = {
+    "Voidling": VillainTemplate("Voidling", 2, 0, 2, "closest", effects=("drain_lp",)),
+    "Shadow Spinner": VillainTemplate("Shadow Spinner", 4, 0, 3, "low_hp", vulnerability="red", effects=("staggered",)),
+    "Void Soldier": VillainTemplate("Void Soldier", 5, 0, 3, "closest", vulnerability="blue", effects=("self_toughened",)),
+    "Dark Wizard": VillainTemplate("Dark Wizard", 10, 1, 3, "high_hp", vulnerability="yellow", effects=("ignore_armor", "push")),
+    "Shadow Banshee": VillainTemplate("Shadow Banshee", 10, 0, 4, "high_lp", vulnerability="grey", effects=("terror",)),
+    "Void Treant": VillainTemplate("Void Treant", 12, 2, 3, "closest", vulnerability="green", effects=("splash",)),
 }
+LEVEL_MODS = {1: (0, 0, 0), 2: (0, 2, 1), 3: (1, 5, 3), 4: (1, 7, 5), 5: (2, 10, 7), 6: (2, 15, 10)}
 
-LEVEL_MODS = {
-    1: (0, 0, 0),
-    2: (0, 2, 1),
-    3: (1, 5, 3),
-    4: (1, 7, 5),
-    5: (2, 10, 7),
-    6: (2, 15, 10),
-}
 
-# Gate subset with key numeric impacts retained
 STANDARD_GATES = [
     Gate("Spiked Gate", "basic", 2, ["red", "red"], start_lp=1),
-    Gate("Cursed Gate", "basic", 2, ["blue", "blue"], start_lp=1),
-    Gate("Reinforced Gate", "basic", 2, ["red", "yellow"], start_lp=1),
+    Gate("Cursed Gate", "basic", 2, ["blue", "blue"], start_lp=1, rule_tag="no_reroll"),
+    Gate("Reinforced Gate", "basic", 2, ["red", "yellow"], start_lp=1, rule_tag="enemy_armor_round1"),
     Gate("Predator's Gate", "basic", 2, ["red", "green"], start_lp=1),
-    Gate("Assassin's Gate", "basic", 2, ["green", "yellow"], start_heal=2),
-    Gate("Painful Gate", "basic", 2, ["grey", "yellow"], start_heal=1, start_lp=1),
+    Gate("Assassin's Gate", "basic", 2, ["green", "yellow"], start_heal=2, rule_tag="enemy_first"),
+    Gate("Painful Gate", "basic", 2, ["grey", "yellow"], start_heal=1, start_lp=1, rule_tag="heal_slows"),
     Gate("Sturdy Gate", "basic", 3, ["red", "blue", "green"], start_heal=1, start_lp=2),
     Gate("Glutton's Gate", "basic", 3, ["blue", "green", "grey"], start_heal=2, start_lp=1),
-    Gate("Glorious Gate", "basic", 3, ["red", "grey", "yellow"], start_lp=3),
-    Gate("Shattering Gate", "basic", 3, ["red", "green", "yellow"], start_lp=2),
-    Gate("Vengeance's Gate", "elite", 5, ["red", "green"], start_lp=2),
-    Gate("Banner's Gate", "elite", 5, ["red", "grey"], start_heal=2),
-    Gate("Fateful Gate", "elite", 5, ["blue", "yellow"], start_lp=1),
-    Gate("Dampened Gate", "elite", 5, ["green", "green"], start_lp=0),
+    Gate("Glorious Gate", "basic", 3, ["red", "grey", "yellow"], start_lp=3, rule_tag="lose_lp_on_kill"),
+    Gate("Shattering Gate", "basic", 3, ["red", "green", "yellow"], start_lp=2, rule_tag="shatterburst"),
+    Gate("Vengeance's Gate", "elite", 5, ["red", "green"], start_lp=2, rule_tag="vengeance"),
+    Gate("Banner's Gate", "elite", 5, ["red", "grey"], start_heal=2, rule_tag="no_positive"),
+    Gate("Fateful Gate", "elite", 5, ["blue", "yellow"], start_lp=1, rule_tag="lp_costs_hp"),
+    Gate("Dampened Gate", "elite", 5, ["green", "green"], rule_tag="pay_special_or_fail"),
     Gate("Large Gate", "elite", 5, ["grey", "grey"], start_lp=1),
     Gate("Temple of Courage", "temple", 1, ["yellow"], start_lp=1),
     Gate("Temple of Mercy", "temple", 1, ["grey"], start_heal=1),
@@ -204,120 +196,64 @@ STANDARD_GATES = [
     Gate("Temple of Purity", "temple", 1, ["yellow"], start_lp=1),
 ]
 NEXUS_GATES = [
-    Gate("Nexus Denied Strength", "nexus", 3, ["blue", "grey"], start_lp=1, start_heal=1),
-    Gate("Nexus Denied Magic", "nexus", 3, ["green", "yellow"], start_lp=2),
-    Gate("Nexus Denied Speed", "nexus", 3, ["red", "blue"], start_lp=1),
-    Gate("Nexus Denied Spirit", "nexus", 3, ["yellow", "yellow"], start_heal=2),
-    Gate("Nexus Denied Faith", "nexus", 3, ["blue", "grey", "yellow"], start_lp=2, start_heal=1),
-    Gate("Nexus Denied Destiny", "nexus", 4, ["red", "red", "blue"], start_lp=3),
+    Gate("Nexus of Denied Strength", "nexus", 3, ["blue", "grey"], start_lp=1, start_heal=1),
+    Gate("Nexus of Denied Magic", "nexus", 3, ["green", "yellow"], start_lp=2),
+    Gate("Nexus of Denied Speed", "nexus", 3, ["red", "blue"], start_lp=1),
+    Gate("Nexus of Denied Spirit", "nexus", 3, ["yellow", "yellow"], start_heal=2),
+    Gate("Nexus of Denied Faith", "nexus", 3, ["blue", "grey", "yellow"], start_lp=2, start_heal=1),
+    Gate("Nexus of Denied Destiny", "nexus", 4, ["red", "red", "blue"], start_lp=3, rule_tag="minus_hero_die"),
 ]
 
-ROOM_SPAWNS = {
-    1: ["Void Soldier", "Shadow Spinner"],
-    2: ["Void Soldier", "Shadow Spinner", "Shadow Spinner"],
-    3: ["VoidTreantFix", "Void Soldier", "Shadow Spinner", "Dark Wizard"],
-    4: ["Void Treant", "Void Soldier", "Shadow Spinner", "Dark Wizard", "Shadow Banshee"],
-    5: ["Void Treant", "Void Soldier", "Void Soldier", "Shadow Spinner", "Dark Wizard"],
-}
 
-# ---------- Boon pools (simplified mechanical projection of listed cards) ----------
+def basic_rooms() -> List[RoomCard]:
+    # uses full room list but single rule tags for key numerical effects
+    data = [
+        ("Steelbound Footing", 2, ["Void Soldier", "Shadow Spinner", "Shadow Spinner"], 3, ["Dark Wizard", "Void Soldier", "Shadow Spinner", "Shadow Spinner"], 5, [("Void Treant", True), ("Void Soldier", False), ("Void Soldier", False), ("Shadow Spinner", False)], "armor_on_engage"),
+        ("Fate’s Favor", 2, ["Void Soldier", "Void Soldier", "Void Soldier"], 3, ["Void Soldier", "Void Soldier", "Void Soldier", "Shadow Spinner"], 5, [("Void Soldier", True), ("Void Soldier", False), ("Void Soldier", False), ("Shadow Spinner", False), ("Shadow Spinner", False)], "free_reroll"),
+        ("The Flanking Hymn", 2, ["Void Soldier", "Void Soldier", "Shadow Spinner"], 3, ["Void Treant", "Void Soldier", "Void Soldier", "Shadow Spinner"], 5, [("Dark Wizard", True), ("Void Soldier", False), ("Void Soldier", False), ("Shadow Spinner", False)], "flank_bonus"),
+        ("Runes of Clarity", 2, ["Dark Wizard", "Void Soldier"], 3, ["Shadow Banshee", "Void Soldier", "Void Soldier", "Shadow Spinner"], 5, [("Shadow Banshee", True), ("Void Soldier", False), ("Void Soldier", False), ("Shadow Spinner", False)], "special_lp_bonus"),
+        ("Prayer of the Bold", 2, ["Void Soldier", "Void Soldier", "Shadow Spinner"], 3, ["Void Soldier", "Void Soldier", "Void Soldier", "Shadow Spinner"], 5, [("Void Treant", True), ("Void Soldier", False), ("Void Soldier", False), ("Shadow Spinner", False)], "empower_if_surrounded"),
+        ("The Mercy Sigil", 2, ["Void Soldier", "Shadow Spinner", "Shadow Spinner"], 3, ["Shadow Spinner", "Shadow Spinner", "Shadow Spinner", "Shadow Spinner"], 5, [("Dark Wizard", True), ("Shadow Spinner", False), ("Shadow Spinner", False), ("Shadow Spinner", False)], "ignore_first_negative"),
+        ("Echo of Teamwork", 2, ["Dark Wizard", "Shadow Spinner"], 3, ["Void Treant", "Void Soldier", "Shadow Spinner", "Shadow Spinner"], 5, [("Void Treant", True), ("Void Soldier", False), ("Shadow Spinner", False), ("Shadow Spinner", False)], "follow_up_die"),
+        ("The Watcher’s Blind Spot", 2, ["Void Soldier", "Void Soldier", "Shadow Spinner"], 3, ["Shadow Banshee", "Void Soldier", "Void Soldier", "Shadow Spinner"], 5, [("Shadow Banshee", True), ("Void Soldier", False), ("Void Soldier", False), ("Shadow Spinner", False)], "none"),
+        ("Shatter-Song Hall", 2, ["Void Soldier", "Void Soldier", "Void Soldier"], 3, ["Void Treant", "Void Soldier", "Void Soldier", "Shadow Spinner"], 5, [("Void Soldier", True), ("Void Treant", False), ("Shadow Spinner", False), ("Shadow Spinner", False)], "none"),
+    ]
+    rooms: List[RoomCard] = []
+    for name, t2, s2, t3, s3, t5, s5, tag in data:
+        rooms.append(RoomCard(name, "basic", {
+            t2: [(x, False) for x in s2],
+            t3: [(x, False) for x in s3],
+            t5: s5,
+        }, tag))
+    return rooms
+
+
+def temple_rooms() -> List[RoomCard]:
+    return [
+        RoomCard("Temple Ruin 2", "temple", {1: [("Shadow Spinner", False), ("Shadow Spinner", False)]}, "temple_exchange"),
+        RoomCard("Temple Ruin 3", "temple", {1: [("Void Soldier", False), ("Shadow Spinner", False)]}, "temple_exchange"),
+        RoomCard("Temple Ruin 4", "temple", {1: [("Void Soldier", False), ("Void Soldier", False)]}, "temple_exchange"),
+        RoomCard("Temple Ruin 5", "temple", {1: [("Void Soldier", False), ("Shadow Spinner", False)]}, "temple_exchange"),
+        RoomCard("Temple Ruin 6", "temple", {1: [("Shadow Spinner", False), ("Shadow Spinner", False)]}, "temple_exchange"),
+    ]
+
+
+def nexus_rooms() -> List[RoomCard]:
+    return [
+        RoomCard("Altar Room 2", "nexus", {3: [("Void Treant", False), ("Void Soldier", False), ("Void Soldier", False), ("Shadow Spinner", False)], 4: [("Void Treant", False), ("Dark Wizard", False), ("Void Soldier", False), ("Void Soldier", False), ("Shadow Spinner", False)]}, "eye_omen"),
+        RoomCard("Altar Room 3", "nexus", {3: [("Dark Wizard", False), ("Void Soldier", False), ("Shadow Spinner", False), ("Shadow Spinner", False)], 4: [("Shadow Banshee", False), ("Dark Wizard", False), ("Void Soldier", False), ("Void Soldier", False), ("Shadow Spinner", False)]}, "eye_omen"),
+        RoomCard("Altar Room 4", "nexus", {3: [("Dark Wizard", False), ("Void Soldier", False), ("Void Soldier", False), ("Shadow Spinner", False)], 4: [("Void Treant", False), ("Dark Wizard", False), ("Void Soldier", False), ("Void Soldier", False), ("Shadow Spinner", False)]}, "eye_omen"),
+    ]
+
+
 def boon_catalog() -> Dict[str, List[Boon]]:
     return {
-        "red": [
-            Boon("Mjolnir’s Spark", "red", {"red": 1}, on_color_special_bonus_damage={"red": 5}),
-            Boon("Hammering Thunder", "red", {"red": 1}, on_attack_flat_bonus=1),
-            Boon("Mighty Storm", "red", {"red": 1}, on_attack_flat_bonus=1),
-            Boon("Stormbreaker", "red", {}, on_color_special_bonus_damage={"red": 4}),
-            Boon("War God’s Might", "red", {"red": 2}),
-            Boon("War God’s Power", "red", {"red": 2}),
-            Boon("Forge of War", "red", {"red": 1}),
-            Boon("Onslaught", "red", {}, on_color_special_bonus_damage={"red": 5}),
-            Boon("Tidal Slam", "red", {}, on_color_special_bonus_damage={"red": 3}),
-            Boon("Maelstrom Crash", "red", {"red": 1}, on_color_special_bonus_damage={"red": 2}),
-            Boon("Far Tide", "red", {"red": 1}),
-            Boon("Command the Currents", "red", {"red": 1}),
-            Boon("Sunshield Strike", "red", {"red": 1}, on_color_special_bonus_damage={"red": 2}),
-            Boon("Winged Aegis", "red", {"red": 1}),
-            Boon("Anointed Armor", "red", {}),
-            Boon("Gaze of the Hawk", "red", {"red": 1}),
-        ],
-        "blue": [
-            Boon("Allfather's Vision", "blue", {"blue": 2}),
-            Boon("Rune Writing", "blue", {"blue": 1}),
-            Boon("Yggdrasil's Sight", "blue", {"blue": 1}),
-            Boon("Runic Sacrifice", "blue", {"blue": 1}),
-            Boon("Nile's Flow", "blue", {"blue": 1}, on_color_special_bonus_lp={"blue": 2}),
-            Boon("Lifebringer", "blue", {}, on_color_special_bonus_lp={"blue": 3}),
-            Boon("Wings of Life", "blue", {"blue": 1}),
-            Boon("Queen's Bloom", "blue", {"blue": 1}),
-            Boon("Queen's Command", "blue", {}, on_color_special_bonus_damage={"blue": 4}),
-            Boon("Wave of Roots", "blue", {"blue": 1}, on_color_special_bonus_damage={"blue": 2}),
-            Boon("Faeric Pride", "blue", {"blue": 1}),
-            Boon("Court's Reverie", "blue", {"blue": 1}, on_kill_lp=3),
-            Boon("Dooming Hex", "blue", {"blue": 1}, on_color_special_bonus_damage={"blue": 2}),
-            Boon("Witch’s Wound", "blue", {"blue": 1}, on_color_special_bonus_damage={"blue": 1}),
-            Boon("Red-Moon Curse", "blue", {"blue": 1}, on_color_special_bonus_damage={"blue": 1}),
-            Boon("Withering Magic", "blue", {"blue": 1}, on_color_special_bonus_damage={"blue": 1}),
-        ],
-        "green": [
-            Boon("Many Masks", "green", {"green": 1}),
-            Boon("Hundred Illusions", "green", {"green": 1}, on_color_special_bonus_lp={"green": 1}),
-            Boon("Chaos Wager", "green", {"green": 1}),
-            Boon("Master of All Tricks", "green", {"green": 1}, on_attack_flat_bonus=2),
-            Boon("Blessing of Alacrity", "green", {"green": 2}),
-            Boon("Luck of the Messenger", "green", {"green": 1}),
-            Boon("Winged Sandals", "green", {"green": 1}),
-            Boon("Wind Step", "green", {"green": 1}),
-            Boon("Desert Plague", "green", {}, on_color_special_bonus_damage={"green": 4}),
-            Boon("Dune Snare", "green", {"green": 1}, on_color_special_bonus_damage={"green": 2}),
-            Boon("Cruelty", "green", {"green": 1}, on_color_special_bonus_damage={"green": 3}),
-            Boon("Cruel Decay", "green", {"green": 1}, on_attack_flat_bonus=1),
-            Boon("Whisper of the Coffin", "green", {"green": 1}, on_attack_flat_bonus=1),
-            Boon("Funeral Ceremony", "green", {}, on_kill_lp=3),
-            Boon("Coffin Nail", "green", {}, on_color_special_bonus_damage={"green": 8}),
-            Boon("Graveyard Smile", "green", {"green": 1}, on_attack_flat_bonus=1),
-        ],
-        "grey": [
-            Boon("Banner of Glory", "grey", {}, on_kill_lp=2),
-            Boon("Athena’s Rally", "grey", {"grey": 1}, on_color_special_bonus_lp={"grey": 1}),
-            Boon("Aegis Blessing", "grey", {"grey": 1}, on_color_special_bonus_lp={"grey": 1}),
-            Boon("Laurel of Nike", "grey", {}, on_color_special_bonus_lp={"grey": 1}),
-            Boon("Scriber's Insight", "grey", {"grey": 2}),
-            Boon("Glyph's Wisdom", "grey", {"grey": 2}),
-            Boon("Ancient Secrets", "grey", {}, on_color_special_bonus_lp={"grey": 4}),
-            Boon("Moon's Manipulation", "grey", {"grey": 1}, on_color_special_bonus_damage={"grey": 1}),
-            Boon("Wave of Mercy", "grey", {"grey": 1}, on_color_special_bonus_lp={"grey": 2}),
-            Boon("Heavenly Will", "grey", {}, on_color_special_bonus_lp={"blue": 2}),
-            Boon("Overflowing Compassion", "grey", {}, on_attack_flat_bonus=1),
-            Boon("Lotus Dance", "grey", {"grey": 1}),
-            Boon("Crow’s Judgment", "grey", {"grey": 1}, on_color_special_bonus_damage={"grey": 2}, on_color_special_bonus_lp={"grey": 3}),
-            Boon("Death's Companion", "grey", {"grey": 1}),
-            Boon("Thousand Pecks", "grey", {"grey": 1}, on_attack_flat_bonus=1),
-            Boon("Raven’s Harvest", "grey", {"grey": 1}),
-        ],
-        "yellow": [
-            Boon("Zeus’ Judgment", "yellow", {}, on_color_special_bonus_damage={"yellow": 7}),
-            Boon("Olympus' Gift", "yellow", {"yellow": 1}, on_attack_flat_bonus=1),
-            Boon("Heaven's Reach", "yellow", {"yellow": 1}, on_attack_flat_bonus=1),
-            Boon("Storm of Wrath", "yellow", {}, on_color_special_bonus_damage={"yellow": 4}),
-            Boon("Whispers of Love", "yellow", {"yellow": 1}),
-            Boon("Protection of the Heart", "yellow", {}, on_color_special_bonus_lp={"yellow": 2}),
-            Boon("Roses to Thorns", "yellow", {"yellow": 1}, on_color_special_bonus_damage={"yellow": 2}),
-            Boon("Chorus of Passion", "yellow", {}, on_color_special_bonus_lp={"yellow": 2}),
-            Boon("Fortress Strike", "yellow", {"yellow": 1}, on_color_special_bonus_damage={"yellow": 2}),
-            Boon("Blessed Iron", "yellow", {}, on_attack_flat_bonus=1),
-            Boon("Thousandfold Retribution", "yellow", {}, on_attack_flat_bonus=1),
-            Boon("Guardian-God’s Defense", "yellow", {"yellow": 1}),
-            Boon("Fey Majesty", "yellow", {"yellow": 2}),
-            Boon("Courtly Glamour", "yellow", {"yellow": 2}),
-            Boon("Royal Flourish", "yellow", {"yellow": 1}, on_color_special_bonus_damage={"yellow": 2}),
-            Boon("Fae Bargain", "yellow", {"yellow": 1}, on_color_special_bonus_lp={"yellow": 8}),
-        ],
+        "red": [Boon("War God’s Might", "red", {"red": 2}), Boon("War God’s Power", "red", {"red": 2}), Boon("Mjolnir’s Spark", "red", {"red": 1}, on_color_special_bonus_damage={"red": 5}), Boon("Onslaught", "red", {}, on_color_special_bonus_damage={"red": 5})],
+        "green": [Boon("Blessing of Alacrity", "green", {"green": 2}), Boon("Wind Step", "green", {"green": 1}), Boon("Whisper of the Coffin", "green", {"green": 1}, on_attack_flat_bonus=2), Boon("Coffin Nail", "green", {}, on_color_special_bonus_damage={"green": 8})],
+        "grey": [Boon("Scriber's Insight", "grey", {"grey": 2}), Boon("Glyph's Wisdom", "grey", {"grey": 2}), Boon("Athena’s Rally", "grey", {"grey": 1}, on_color_special_bonus_lp={"grey": 1}), Boon("Ancient Secrets", "grey", {}, on_color_special_bonus_lp={"grey": 4})],
+        "blue": [Boon("Allfather's Vision", "blue", {"blue": 2}), Boon("Rune Writing", "blue", {"blue": 1}), Boon("Nile's Flow", "blue", {"blue": 1}, on_color_special_bonus_lp={"blue": 2}), Boon("Dooming Hex", "blue", {"blue": 1}, on_color_special_bonus_damage={"blue": 2})],
+        "yellow": [Boon("Fey Majesty", "yellow", {"yellow": 2}), Boon("Courtly Glamour", "yellow", {"yellow": 2}), Boon("Zeus’ Judgment", "yellow", {}, on_color_special_bonus_damage={"yellow": 7}), Boon("Fae Bargain", "yellow", {"yellow": 1}, on_color_special_bonus_lp={"yellow": 8})],
     }
-
-
-def clamp(v: int, lo: int, hi: int) -> int:
-    return max(lo, min(hi, v))
 
 
 def roll_die() -> str:
@@ -329,114 +265,134 @@ def roll_die() -> str:
     return "blank"
 
 
-def choose_gate(taint: int) -> Gate:
-    options = random.sample(STANDARD_GATES, 2) + [random.choice(NEXUS_GATES)]
-    best = None
-    best_score = -1e9
-    for g in options:
-        score = len(g.fragments) * 1.4 - g.threat * 1.1
-        if g.gate_type == "nexus":
-            score -= 0.8 if taint < 10 else -0.2
-        if taint >= 12 and g.gate_type in ("temple", "nexus"):
-            score += 1.2
-        if score > best_score:
-            best_score = score
-            best = g
-    return best
+def clamp(v: int, lo: int, hi: int) -> int:
+    return max(lo, min(hi, v))
 
 
-def spawn_for_threat(threat: int, spawn_level: int) -> List[Enemy]:
-    if threat == 3:
-        names = ["Void Treant", "Void Soldier", "Shadow Spinner", "Dark Wizard"]
-    elif threat >= 4:
-        names = ["Void Treant", "Void Soldier", "Void Soldier", "Shadow Spinner", "Dark Wizard"]
-    elif threat == 2:
-        names = ["Void Soldier", "Shadow Spinner", "Shadow Spinner"]
+def init_deck(cards: List):
+    deck = cards.copy()
+    random.shuffle(deck)
+    return deck
+
+
+def draw_one(deck: List, refill: Optional[List] = None):
+    if not deck and refill:
+        deck.extend(refill.copy())
+        random.shuffle(deck)
+    return deck.pop() if deck else None
+
+
+def apply_condition(entity: HeroState | Enemy, incoming: str):
+    opp = OPPOSING.get(incoming)
+    if opp and opp in entity.conditions:
+        entity.conditions.remove(opp)
+        weaker = CONDITION_LADDERS.get(opp, [opp])[0]
+        if weaker in entity.conditions:
+            entity.conditions.remove(weaker)
+        return
+
+    if incoming in CONDITION_LADDERS:
+        weak, strong = CONDITION_LADDERS[incoming]
+        if strong in entity.conditions:
+            return
+        if weak in entity.conditions:
+            entity.conditions.remove(weak)
+            entity.conditions.add(strong)
+            return
+        entity.conditions.add(weak)
     else:
-        names = ["Void Soldier", "Shadow Spinner"]
-
-    enemies = []
-    for n in names:
-        vt = VILLAINS[n]
-        a_mod, hp_mod, d_mod = LEVEL_MODS[spawn_level]
-        enemies.append(
-            Enemy(vt, hp=vt.hp + hp_mod, armor=vt.armor + a_mod, damage=vt.damage + d_mod, level=spawn_level)
-        )
-    return enemies
-
-
-def apply_condition(target: HeroState | Enemy, cond: str):
-    target.conditions[cond] += 1
+        entity.conditions.add(incoming)
 
 
 def remove_surge_conditions(heroes: List[HeroState], enemies: List[Enemy]):
-    positive = {"empowered", "exalted", "toughened", "armored"}
-    negative = {"weakened", "enfeebled", "exposed", "breached", "bleeding", "hemorrhaging", "staggered", "slowed"}
     for h in heroes:
-        for c in list(h.conditions):
-            if c in positive:
-                del h.conditions[c]
+        h.conditions = {c for c in h.conditions if c not in POSITIVE_CONDS}
     for e in enemies:
-        for c in list(e.conditions):
-            if c in negative:
-                del e.conditions[c]
+        e.conditions = {c for c in e.conditions if c not in NEGATIVE_CONDS}
+
+
+def spawn_from_card(room: RoomCard, threat: int, spawn_level: int) -> List[Enemy]:
+    entries = room.spawns_by_threat.get(threat) or room.spawns_by_threat.get(3) or room.spawns_by_threat[min(room.spawns_by_threat)]
+    enemies: List[Enemy] = []
+    for name, elite in entries:
+        lvl = min(6, spawn_level + (1 if elite else 0))
+        a, hp_b, d = LEVEL_MODS[lvl]
+        t = VILLAINS[name]
+        enemies.append(Enemy(t, t.hp + hp_b, t.armor + a, t.damage + d, lvl))
+    return enemies
+
+
+def choose_target_enemy(enemies: List[Enemy]) -> Optional[Enemy]:
+    alive = [e for e in enemies if e.alive]
+    return min(alive, key=lambda e: (e.hp, -e.damage)) if alive else None
+
+
+def choose_enemy_target(enemy: Enemy, heroes: List[HeroState]) -> Optional[HeroState]:
+    alive = [h for h in heroes if h.alive]
+    if not alive:
+        return None
+    if enemy.template.target_rule == "low_hp":
+        return min(alive, key=lambda h: h.hp)
+    if enemy.template.target_rule == "high_hp":
+        return max(alive, key=lambda h: h.hp)
+    if enemy.template.target_rule == "high_lp":
+        return max(alive, key=lambda h: h.lp)
+    return min(alive, key=lambda h: h.hp)
 
 
 def pick_attack(hero: HeroState, enemies: List[Enemy]) -> Attack:
-    alive_enemies = [e for e in enemies if e.alive]
-    tanky = any(e.hp >= 10 for e in alive_enemies)
     if hero.lp >= 6:
         return hero.template.attacks[3]
-    if hero.lp >= hero.template.attacks[2].lp_cost and tanky:
+    if hero.lp >= hero.template.attacks[2].lp_cost and any(e.hp >= 10 for e in enemies if e.alive):
         return hero.template.attacks[2]
-    # choose best builder by expected damage rough score
     b1, b2 = hero.template.attacks[0], hero.template.attacks[1]
-    s1 = sum(b1.base_dice.values()) + b1.lp_gain * 0.7
-    s2 = sum(b2.base_dice.values()) + b2.lp_gain * 0.7
-    return b1 if s1 >= s2 else b2
+    return b1 if (sum(b1.base_dice.values()) + 0.6 * b1.lp_gain) >= (sum(b2.base_dice.values()) + 0.6 * b2.lp_gain) else b2
 
 
-def target_enemy(enemies: List[Enemy], damage_type: Optional[str] = None) -> Optional[Enemy]:
-    alive = [e for e in enemies if e.alive]
-    if not alive:
-        return None
-    # focus low hp to reduce incoming attacks
-    alive.sort(key=lambda e: (e.hp, -e.damage))
-    return alive[0]
+def try_reroll(face: str, hero: HeroState, gate: Gate, room: RoomCard) -> str:
+    if face != "blank":
+        return face
+    if gate.rule_tag == "no_reroll":
+        return face
+    free = room.rule_tag == "free_reroll" and not hero.reroll_free_this_round
+    if free and random.random() < 0.8:
+        hero.reroll_free_this_round = True
+        return roll_die()
+    if hero.lp > 0 and random.random() < 0.35:
+        hero.lp -= 1
+        return roll_die()
+    return face
 
 
-def resolve_hero_attack(
-    hero: HeroState,
-    enemies: List[Enemy],
-    seals: List[str],
-    boon_cp: Dict[str, float],
-    gate: Gate,
-) -> None:
+def resolve_hero_attack(hero: HeroState, enemies: List[Enemy], seals: List[str], boon_cp: Dict[str, float], gate: Gate, room: RoomCard, round_no: int):
     if not hero.alive:
         return
-    if hero.conditions.get("staggered", 0) > 0:
-        del hero.conditions["staggered"]
+    if "staggered" in hero.conditions:
+        hero.conditions.remove("staggered")
         return
 
     atk = pick_attack(hero, enemies)
     if hero.lp < atk.lp_cost:
         atk = hero.template.attacks[0]
 
-    lp_spent = atk.lp_cost
-    if atk.full_spender:
-        lp_spent = max(3, hero.lp)
+    lp_spent = max(3, hero.lp) if atk.full_spender else atk.lp_cost
     hero.lp = clamp(hero.lp - lp_spent, 0, 12)
+    if gate.rule_tag == "lp_costs_hp" and lp_spent > 0:
+        hero.hp -= max(0, lp_spent - (1 if hero.first_attack_this_round else 0))
+
+    if gate.rule_tag == "pay_special_or_fail" and random.random() < 0.3:
+        return
 
     pool: List[Tuple[str, Optional[str]]] = []
-    for color, n in atk.base_dice.items():
-        n_roll = n
-        if atk.full_spender and color == "red" and hero.template.name == "Hercules":
-            n_roll += max(0, lp_spent - 3)
-        if atk.full_spender and color == "green" and hero.template.name == "Anansi":
-            n_roll = lp_spent
-        for _ in range(n_roll):
-            pool.append((color, None))
-
+    for c, n in atk.base_dice.items():
+        if atk.full_spender and c == "red" and hero.template.name == "Hercules":
+            n += max(0, lp_spent - 3)
+        if atk.full_spender and c == "green" and hero.template.name == "Anansi":
+            n = lp_spent
+        if gate.rule_tag == "minus_hero_die":
+            n = max(1, n - 1)
+        for _ in range(n):
+            pool.append((c, None))
     pool.append((hero.template.relic_die_color, None))
 
     for b in hero.boons:
@@ -444,146 +400,142 @@ def resolve_hero_attack(
             for _ in range(n):
                 pool.append((c, b.name))
 
-    results: List[Tuple[str, str, Optional[str]]] = []
-    for color, src in pool:
-        face = roll_die()
-        # simple reroll policy: spend LP on blank up to 2 rerolls
-        if face == "blank" and hero.lp > 0 and random.random() < 0.35:
-            hero.lp -= 1
-            face = roll_die()
-        results.append((color, face, src))
+    # seal channeling
+    if len(seals) >= 2:
+        c = Counter(seals).most_common(1)[0][0]
+        if seals.count(c) >= 2 and random.random() < 0.2:
+            seals.remove(c); seals.remove(c)
+            pool.append((c, "sealed_channel"))
 
-    # count results
+    rolled: List[Tuple[str, str, Optional[str]]] = []
+    for c, src in pool:
+        face = try_reroll(roll_die(), hero, gate, room)
+        rolled.append((c, face, src))
+
+    specials = Counter()
     dmg = 0
-    specials_by_color = Counter()
-    blanks = 0
-    for color, face, src in results:
+    for c, face, src in rolled:
         if face == "dmg":
             dmg += 1
-            if src:
+            if src and src not in ("sealed_channel",):
                 boon_cp[src] += CP_DAMAGE
         elif face == "special":
-            specials_by_color[color] += 1
+            specials[c] += 1
+
+    # bank 1 seal (or Merlin rune slot)
+    if sum(specials.values()) > 0 and len(seals) < 6 and random.random() < 0.45:
+        k = specials.most_common(1)[0][0]
+        specials[k] -= 1
+        if specials[k] <= 0:
+            del specials[k]
+        if hero.template.name == "Merlin" and len(hero.rune_slots) < 3 and random.random() < 0.5:
+            hero.rune_slots.append(k)
+            if len(hero.rune_slots) == 3 and random.random() < 0.5:
+                # completed spell: distribute LP
+                for ally in random.sample([h for h in HERO_STATES if h.alive], k=min(4, len([h for h in HERO_STATES if h.alive]))):
+                    ally.lp = clamp(ally.lp + 1, 0, 12)
+                seals.extend(hero.rune_slots)
+                hero.rune_slots.clear()
         else:
-            blanks += 1
+            seals.append(k)
 
-    # once/turn bank one seal before spending specials
-    if len(seals) < 6 and sum(specials_by_color.values()) > 0 and random.random() < 0.45:
-        c = max(specials_by_color, key=specials_by_color.get)
-        specials_by_color[c] -= 1
-        if specials_by_color[c] <= 0:
-            del specials_by_color[c]
-        seals.append(c)
-
-    # base attack special rules (spend one matching special for +2 dmg per trigger)
     for c, req in atk.special_rules.items():
-        if specials_by_color.get(c, 0) >= req:
-            specials_by_color[c] -= req
+        if specials.get(c, 0) >= req:
+            specials[c] -= req
             dmg += 2
 
-    # boon triggered effects
     for b in hero.boons:
-        for c, bdmg in b.on_color_special_bonus_damage.items():
-            if specials_by_color.get(c, 0) >= 1:
-                specials_by_color[c] -= 1
-                dmg += bdmg
-                boon_cp[b.name] += bdmg * CP_DAMAGE
-        for c, blp in b.on_color_special_bonus_lp.items():
-            if specials_by_color.get(c, 0) >= 1:
-                specials_by_color[c] -= 1
-                hero.lp = clamp(hero.lp + blp, 0, 12)
-                boon_cp[b.name] += blp * CP_LP
+        for c, extra in b.on_color_special_bonus_damage.items():
+            if specials.get(c, 0) >= 1:
+                specials[c] -= 1
+                dmg += extra
+                boon_cp[b.name] += extra * CP_DAMAGE
+        for c, lp in b.on_color_special_bonus_lp.items():
+            if specials.get(c, 0) >= 1:
+                specials[c] -= 1
+                hero.lp = clamp(hero.lp + lp, 0, 12)
+                boon_cp[b.name] += lp * CP_LP
         if b.on_attack_flat_bonus:
             dmg += b.on_attack_flat_bonus
             boon_cp[b.name] += b.on_attack_flat_bonus * CP_DAMAGE
 
-    # remaining specials -> LP or damage heuristic
-    for c, n in list(specials_by_color.items()):
+    for _, n in specials.items():
         for _ in range(n):
             if hero.lp <= 4:
                 hero.lp = clamp(hero.lp + 2, 0, 12)
             else:
                 dmg += 2
 
-    dmg += atk.lp_gain * 0  # lp gain handled below
-    hero.lp = clamp(hero.lp + atk.lp_gain, 0, 12)
-
-    # condition modifiers
-    if hero.conditions.get("empowered", 0):
+    if "empowered" in hero.conditions:
         dmg += 1
-    if hero.conditions.get("exalted", 0):
+    if "exalted" in hero.conditions:
         dmg += 3
-    if hero.conditions.get("weakened", 0):
+    if "weakened" in hero.conditions:
         dmg -= 1
-    if hero.conditions.get("enfeebled", 0):
+    if "enfeebled" in hero.conditions:
         dmg -= 3
-    dmg = max(0, dmg)
+    if room.rule_tag == "flank_bonus" and random.random() < 0.35:
+        dmg += 1
+    if room.rule_tag == "follow_up_die" and not hero.first_attack_this_round and random.random() < 0.5:
+        dmg += 1 if roll_die() == "dmg" else 0
+    if gate.rule_tag == "enemy_armor_round1" and round_no == 1:
+        dmg = max(0, dmg - 1)
 
-    target = target_enemy(enemies)
+    hero.lp = clamp(hero.lp + atk.lp_gain, 0, 12)
+    target = choose_target_enemy(enemies)
     if not target:
         return
 
-    # approximate type by most common die in attack
-    damage_type = max(atk.base_dice.items(), key=lambda kv: kv[1])[0] if atk.base_dice else "red"
-
-    # vulnerability / resistance
-    if target.template.vulnerability == damage_type:
+    dtype = max(atk.base_dice.items(), key=lambda kv: kv[1])[0] if atk.base_dice else "red"
+    if target.template.vulnerability == dtype:
         dmg *= 2
-    if target.template.resistance == damage_type:
-        dmg //= 2
-
-    # armor application
-    post = max(0, dmg - target.armor)
-    target.hp -= post
-    hero.damage_done_this_room += post
+    dealt = max(0, dmg - target.armor)
+    target.hp -= dealt
+    hero.damage_done_this_room += dealt
 
     if target.hp <= 0:
         for b in hero.boons:
             if b.on_kill_lp:
                 hero.lp = clamp(hero.lp + b.on_kill_lp, 0, 12)
                 boon_cp[b.name] += b.on_kill_lp * CP_LP
+        if gate.rule_tag == "lose_lp_on_kill":
+            hero.lp = max(0, hero.lp - 1)
+        if gate.rule_tag == "shatterburst":
+            hero.hp -= 1
+        if gate.rule_tag == "vengeance":
+            for e in enemies:
+                if e.alive:
+                    apply_condition(e, "empowered")
+
+    hero.first_attack_this_round = False
 
 
-def choose_target_for_enemy(enemy: Enemy, heroes: List[HeroState]) -> Optional[HeroState]:
-    alive = [h for h in heroes if h.alive]
-    if not alive:
-        return None
-    if enemy.template.target_rule == "low_hp":
-        return min(alive, key=lambda h: h.hp)
-    if enemy.template.target_rule == "high_lp":
-        return max(alive, key=lambda h: h.lp)
-    if enemy.template.target_rule == "high_hp":
-        return max(alive, key=lambda h: h.hp)
-    return min(alive, key=lambda h: h.hp)
-
-
-def resolve_enemy_attack(enemy: Enemy, heroes: List[HeroState], taint: List[int]):
-    if not enemy.alive:
-        return
-    target = choose_target_for_enemy(enemy, heroes)
+def resolve_enemy_attack(enemy: Enemy, heroes: List[HeroState], taint: List[int], round_no: int):
+    target = choose_enemy_target(enemy, heroes)
     if not target:
         return
     dmg = enemy.damage
-    if enemy.conditions.get("weakened", 0):
+    if "weakened" in enemy.conditions:
         dmg = max(0, dmg - 1)
-    if enemy.conditions.get("enfeebled", 0):
+    if "enfeebled" in enemy.conditions:
         dmg = max(0, dmg - 3)
+    if "empowered" in enemy.conditions:
+        dmg += 1
+    if "exalted" in enemy.conditions:
+        dmg += 3
 
-    incoming = dmg
-    if target.conditions.get("exposed", 0):
-        incoming += 1
-    if target.conditions.get("breached", 0):
-        incoming += 3
+    if "exposed" in target.conditions:
+        dmg += 1
+    if "breached" in target.conditions:
+        dmg += 3
 
-    ignore_armor = "ignore_armor" in enemy.template.effects
-    if not ignore_armor:
-        prevented = min(target.armor, incoming)
-        incoming -= prevented
+    if "ignore_armor" not in enemy.template.effects:
+        prevented = min(target.armor, dmg)
+        dmg -= prevented
         if prevented > 0:
             target.armor = max(0, target.armor - 1)
 
-    target.hp -= incoming
-
+    target.hp -= dmg
     if "drain_lp" in enemy.template.effects:
         target.lp = max(0, target.lp - 1)
     if "staggered" in enemy.template.effects:
@@ -591,23 +543,19 @@ def resolve_enemy_attack(enemy: Enemy, heroes: List[HeroState], taint: List[int]
     if "self_toughened" in enemy.template.effects:
         enemy.armor += 1
     if "splash" in enemy.template.effects:
-        others = [h for h in heroes if h.alive and h is not target]
-        if others:
-            splash = random.choice(others)
-            splash.hp -= 1
+        for other in random.sample([h for h in heroes if h.alive and h is not target], k=min(1, len([h for h in heroes if h.alive and h is not target]))):
+            other.hp -= 1
+    if "terror" in enemy.template.effects and random.random() < 0.4:
+        for h in heroes:
+            if h.alive:
+                h.lp = max(0, h.lp - 1)
 
     if target.hp <= 0 and target.alive:
         target.alive = False
         taint[0] += 1
 
 
-def attempt_fragment_claim(
-    hero: HeroState,
-    fragments_left: List[str],
-    seals: List[str],
-    taint: List[int],
-    decks: Dict[str, List[Boon]],
-):
+def attempt_fragment_claim(hero: HeroState, fragments_left: List[str], seals: List[str], taint: List[int], decks: Dict[str, List[Boon]]):
     if not hero.alive or not fragments_left:
         return
     chance = 0.28 + (0.08 if hero.lp >= 4 else 0)
@@ -620,38 +568,76 @@ def attempt_fragment_claim(
     else:
         taint[0] += 1
 
-    candidates = random.sample(decks[color], k=3)
-    # choose by simple score = dice + effect potential
-    def score(b: Boon):
-        return sum(b.dice_bonus.values()) * 3 + b.on_attack_flat_bonus + sum(b.on_color_special_bonus_damage.values()) * 0.4 + sum(b.on_color_special_bonus_lp.values()) * 0.35 + b.on_kill_lp * 0.3
+    draw_n = 3
+    if hero.lp >= 1 and random.random() < 0.25:
+        pay = min(3, hero.lp)
+        hero.lp -= pay
+        draw_n += pay
 
-    pick = max(candidates, key=score)
+    picks = random.sample(decks[color], k=min(draw_n, len(decks[color])))
+    pick = max(picks, key=lambda b: sum(b.dice_bonus.values()) * 3 + b.on_attack_flat_bonus + 0.4 * sum(b.on_color_special_bonus_damage.values()) + 0.35 * sum(b.on_color_special_bonus_lp.values()) + b.on_kill_lp * 0.3)
     hero.boons.append(pick)
 
 
-def run_single() -> Dict:
-    heroes = [HeroState(template=h, hp=h.max_hp) for h in HEROES]
+def choose_gate(taint: int, std_deck: List[Gate], nexus_deck: List[Gate]) -> Gate:
+    std1 = draw_one(std_deck, STANDARD_GATES)
+    std2 = draw_one(std_deck, STANDARD_GATES)
+    nx = draw_one(nexus_deck, NEXUS_GATES)
+    options = [x for x in [std1, std2, nx] if x is not None]
+    best = options[0]
+    best_score = -1e9
+    for g in options:
+        score = 1.4 * len(g.fragments) - 1.1 * g.threat
+        if g.gate_type == "nexus":
+            score += 0.5 if taint > 11 else -0.5
+        if g.gate_type == "temple" and taint > 10:
+            score += 1.0
+        if score > best_score:
+            best_score = score
+            best = g
+    return best
+
+
+def apply_room_start(heroes: List[HeroState], gate: Gate, room: RoomCard, taint: List[int]):
+    for h in heroes:
+        if not h.alive:
+            continue
+        h.lp = clamp(h.lp + gate.start_lp, 0, 12)
+        if gate.start_heal:
+            h.hp = min(h.template.max_hp, h.hp + gate.start_heal)
+            if gate.rule_tag == "heal_slows":
+                apply_condition(h, "slowed")
+        if room.rule_tag == "temple_exchange" and random.random() < 0.25:
+            taint[0] = max(0, taint[0] - 1)
+
+
+def run_single(max_rounds_safety: int = 16) -> Dict:
+    global HERO_STATES
+    heroes = [HeroState(h, h.max_hp) for h in HEROES]
+    HERO_STATES = heroes
     decks = boon_catalog()
+    std_gate_deck = init_deck(STANDARD_GATES)
+    nexus_gate_deck = init_deck(NEXUS_GATES)
+    basic_room_deck = init_deck(basic_rooms())
+    temple_room_deck = init_deck(temple_rooms())
+    nexus_room_deck = init_deck(nexus_rooms())
+
     seals: List[str] = []
     taint = [0]
     spawn_level = 1
-
-    room_hp = []
-    room_damage = []
-    room_taint = []
+    room_hp, room_damage, room_taint = [], [], []
     boon_cp = defaultdict(float)
 
     for room_idx in range(1, MAX_ROOMS + 1):
-        # room reset
         for h in heroes:
             if h.alive:
                 h.lp = 0
                 h.armor = 0
+                h.first_attack_this_round = True
             h.damage_done_this_room = 0.0
 
-        gate = choose_gate(taint[0])
+        gate = choose_gate(taint[0], std_gate_deck, nexus_gate_deck)
 
-        # unseal heuristic
         if any(f in seals for f in gate.fragments):
             for f in gate.fragments:
                 if f in seals:
@@ -659,46 +645,55 @@ def run_single() -> Dict:
                     taint[0] = max(0, taint[0] - 1)
                     break
 
-        # start bonuses
-        for h in heroes:
-            if not h.alive:
-                continue
-            h.lp = clamp(h.lp + gate.start_lp, 0, 12)
-            if gate.start_heal > 0:
-                h.hp = min(h.template.max_hp, h.hp + gate.start_heal)
+        if gate.gate_type == "temple":
+            room = draw_one(temple_room_deck, temple_rooms())
+        elif gate.gate_type == "nexus":
+            room = draw_one(nexus_room_deck, nexus_rooms())
+        else:
+            room = draw_one(basic_room_deck, basic_rooms())
 
-        enemies = spawn_for_threat(gate.threat, spawn_level)
+        apply_room_start(heroes, gate, room, taint)
+
+        enemies = spawn_from_card(room, gate.threat, spawn_level)
         fragments = gate.fragments.copy()
-
-        round_num = 0
         collapse_pending = False
-        while any(e.alive for e in enemies) and any(h.alive for h in heroes) and round_num < 8:
-            round_num += 1
+        round_no = 0
+
+        while any(e.alive for e in enemies) and any(h.alive for h in heroes) and round_no < max_rounds_safety:
+            round_no += 1
+            for h in heroes:
+                h.reroll_free_this_round = False
+                h.first_attack_this_round = True
+                if room.rule_tag == "empower_if_surrounded" and random.random() < 0.35:
+                    apply_condition(h, "empowered")
+
             initiative = [h.template.name for h in heroes if h.alive] + [f"E{i}" for i, e in enumerate(enemies) if e.alive]
             random.shuffle(initiative)
-            if "Assassin" in gate.name:
-                initiative.sort(key=lambda x: 0 if x.startswith("E") else 1)
+            if gate.rule_tag == "enemy_first":
+                initiative.sort(key=lambda t: 0 if t.startswith("E") else 1)
 
             for token in initiative:
                 if token.startswith("E"):
-                    idx = int(token[1:])
-                    if 0 <= idx < len(enemies) and enemies[idx].alive:
-                        resolve_enemy_attack(enemies[idx], heroes, taint)
+                    enemy = enemies[int(token[1:])]
+                    if enemy.alive:
+                        resolve_enemy_attack(enemy, heroes, taint, round_no)
                 else:
                     hero = next(h for h in heroes if h.template.name == token)
-                    if hero.alive:
-                        hero.armor = 0  # armor decay at start turn
-                        resolve_hero_attack(hero, enemies, seals, boon_cp, gate)
-                        attempt_fragment_claim(hero, fragments, seals, taint, decks)
-                        if hero.conditions.get("bleeding", 0):
-                            hero.hp -= 1
-                        if hero.conditions.get("hemorrhaging", 0):
-                            hero.hp -= 3
-                        if hero.hp <= 0 and hero.alive:
-                            hero.alive = False
-                            taint[0] += 1
+                    if not hero.alive:
+                        continue
+                    hero.armor = 0
+                    if "slowed" in hero.conditions and random.random() < 0.25:
+                        hero.conditions.remove("slowed")
+                    resolve_hero_attack(hero, enemies, seals, boon_cp, gate, room, round_no)
+                    attempt_fragment_claim(hero, fragments, seals, taint, decks)
+                    if "bleeding" in hero.conditions:
+                        hero.hp -= 1
+                    if "hemorrhaging" in hero.conditions:
+                        hero.hp -= 3
+                    if hero.hp <= 0 and hero.alive:
+                        hero.alive = False
+                        taint[0] += 1
 
-            # round end taint + despair
             taint[0] += 1
             despair = 0 if taint[0] <= 5 else 1 if taint[0] <= 10 else 2 if taint[0] <= 15 else 3
             for h in heroes:
@@ -717,11 +712,7 @@ def run_single() -> Dict:
                     h.hp = 0
                 break
 
-        # room clear resurrect rule
-        if any(e.alive for e in enemies):
-            # room failure: keep dead as dead for this run
-            pass
-        else:
+        if not any(e.alive for e in enemies):
             for h in heroes:
                 if not h.alive:
                     h.alive = True
@@ -734,7 +725,6 @@ def run_single() -> Dict:
         room_taint.append(taint[0])
 
         if not any(h.alive for h in heroes):
-            # fill remaining rooms with zeros
             for _ in range(room_idx + 1, MAX_ROOMS + 1):
                 room_hp.append({h.template.name: 0 for h in heroes})
                 room_damage.append({h.template.name: 0.0 for h in heroes})
@@ -750,31 +740,33 @@ def run_single() -> Dict:
     }
 
 
-def aggregate(sim_results: List[Dict]) -> Dict:
-    hero_names = [h.name for h in HEROES]
-    avg_hp = []
-    avg_dmg = []
-    avg_taint = []
+def aggregate(results: List[Dict]) -> Dict:
+    names = [h.name for h in HEROES]
+    avg_hp, avg_dmg, avg_taint = [], [], []
+    for i in range(MAX_ROOMS):
+        avg_hp.append({n: statistics.fmean(r["room_hp"][i][n] for r in results) for n in names})
+        avg_dmg.append({n: statistics.fmean(r["room_damage"][i][n] for r in results) for n in names})
+        avg_taint.append(statistics.fmean(r["room_taint"][i] for r in results))
 
-    for r in range(MAX_ROOMS):
-        hp_row = {}
-        dmg_row = {}
-        for hn in hero_names:
-            hp_row[hn] = statistics.fmean(res["room_hp"][r][hn] for res in sim_results)
-            dmg_row[hn] = statistics.fmean(res["room_damage"][r][hn] for res in sim_results)
-        avg_hp.append(hp_row)
-        avg_dmg.append(dmg_row)
-        avg_taint.append(statistics.fmean(res["room_taint"][r] for res in sim_results))
+    boon_totals = defaultdict(float)
+    for r in results:
+        for k, v in r["boon_cp"].items():
+            boon_totals[k] += v
+    boon_avg = {k: v / len(results) for k, v in sorted(boon_totals.items(), key=lambda kv: kv[1], reverse=True)}
 
-    total_boon_cp = defaultdict(float)
-    for res in sim_results:
-        for k, v in res["boon_cp"].items():
-            total_boon_cp[k] += v
+    return {
+        "avg_hp": avg_hp,
+        "avg_dmg": avg_dmg,
+        "avg_taint": avg_taint,
+        "boon_cp_avg": boon_avg,
+        "survival_rate": statistics.fmean(r["survived_7"] for r in results),
+    }
 
-    boon_avg = {k: v / len(sim_results) for k, v in sorted(total_boon_cp.items(), key=lambda kv: kv[1], reverse=True)}
 
-    survival_rate = statistics.fmean(res["survived_7"] for res in sim_results)
-    return {"avg_hp": avg_hp, "avg_dmg": avg_dmg, "avg_taint": avg_taint, "boon_cp_avg": boon_avg, "survival_rate": survival_rate}
+def run_simulations(n: int = DEFAULT_SIMS, seed: int = 42, max_rounds_safety: int = 16) -> Dict:
+    random.seed(seed)
+    results = [run_single(max_rounds_safety=max_rounds_safety) for _ in range(n)]
+    return aggregate(results)
 
 
 def print_report(agg: Dict, sims: int):
@@ -784,11 +776,11 @@ def print_report(agg: Dict, sims: int):
         print(f"\nRoom {i+1}")
         print(f"  Avg Taint: {agg['avg_taint'][i]:.2f}")
         print("  Avg Hero HP at room end:")
-        for hn, val in agg["avg_hp"][i].items():
-            print(f"    - {hn:12s}: {val:6.2f}")
+        for hn, v in agg["avg_hp"][i].items():
+            print(f"    - {hn:12s}: {v:6.2f}")
         print("  Avg damage dealt by hero in this room:")
-        for hn, val in agg["avg_dmg"][i].items():
-            print(f"    - {hn:12s}: {val:6.2f}")
+        for hn, v in agg["avg_dmg"][i].items():
+            print(f"    - {hn:12s}: {v:6.2f}")
 
     print(f"\nEstimated run survival to room 7: {agg['survival_rate']*100:.2f}%")
     print("\nTop 40 Boon cards by average CP contribution per run")
@@ -797,21 +789,14 @@ def print_report(agg: Dict, sims: int):
         print(f"{i:2d}. {name:32s} {cp:8.3f} CP/run")
 
 
-def run_simulations(n: int = DEFAULT_SIMS, seed: int = 42):
-    random.seed(seed)
-    results = []
-    for _ in range(n):
-        results.append(run_single())
-    return aggregate(results)
-
-
 if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="Spellrift Dungeons alpha balance simulator")
-    parser.add_argument("--sims", type=int, default=DEFAULT_SIMS, help="number of Monte Carlo simulations (default: 20000)")
-    parser.add_argument("--seed", type=int, default=42, help="random seed")
+    parser.add_argument("--sims", type=int, default=DEFAULT_SIMS)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--max-rounds-safety", type=int, default=16)
     args = parser.parse_args()
 
-    aggregated = run_simulations(args.sims, args.seed)
+    aggregated = run_simulations(args.sims, args.seed, args.max_rounds_safety)
     print_report(aggregated, args.sims)


### PR DESCRIPTION
### Motivation
- Provide a runnable Monte‑Carlo simulator that follows the GDD intent while honoring the user constraint to ignore grid/terrain (assume average engagement).
- Model the economic and combat systems that matter for balance: dice, Specials, Seal banking/channeling, Fragment → Boon drafting, LP flow, conditions, Taint/Surge, initiative and villain scaling so we can report per‑room analytics up to room 7.
- Produce stable, repeatable averages after 20,000 runs for: end‑of‑room HP per hero, damage per hero per room, boon CP contribution, and room Taint.

### Description
- Reworked `spellrift_balance_sim.py` into an abstract, positionless simulator that models initiative, per‑turn resolution, specials → LP/damage decisions, rerolls, Seal banking/channeling and Merlin rune flow, Fragment claiming with Seal cost, and simplified boon effects; added finite shuffled gate/room decks and threat‑based spawns. (see `spellrift_balance_sim.py`.)
- Added structured condition ladders/opposition and surge cleanup, spawn level scaling on Surges, collapse rules, room end resurrection, and a `--max-rounds-safety` cap to avoid pathological loops. (Room/taint/surge lifecycle now routed centrally.)
- Introduced data models for gates, room cards, villains, heroes, boons and enemies; implemented a boon catalog (representative subset) and a scoring policy for drafting and in‑combat boon effects to compute CP contribution per boon. (Representative room/gate rule tags implemented as probabilistic/numeric hooks.)
- Replaced the long gap plan with a concise post‑implementation `SIM_GDD_GAP_PLAN.md` that documents remaining fidelity gaps (full boon text, full hero unique abilities, boss phase, exact task predicates, etc.) and updated `README.md` with usage and the safety flag.

### Testing
- Static check: `python3 -m py_compile spellrift_balance_sim.py` (succeeded).
- Quick smoke run: `python3 spellrift_balance_sim.py --sims 100 --seed 42 --max-rounds-safety 16` (succeeded and produced per‑room summaries).
- Full requested Monte‑Carlo verification: `python3 spellrift_balance_sim.py --sims 20000 --seed 42 --max-rounds-safety 16` (completed; produced room 1..7 averages, survival rate, and top boon CP contributors; run time observed ~28s in this environment).
- All tests succeeded; `SIM_GDD_GAP_PLAN.md` lists the remaining work required to reach full strict GDD fidelity (not required for the requested analysis but available for next steps).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984325dc8d4832ab3ed19493a37f155)